### PR TITLE
Bugsnag tests from 02/16/2016

### DIFF
--- a/ios/01/_bugsnag_arm64.crash
+++ b/ios/01/_bugsnag_arm64.crash
@@ -3,25 +3,24 @@ Exception Subtype: KERN_INVALID_ADDRESS
 Attempted to dereference garbage pointer 0x1.
 
 0  libsystem_platform.dylib _platform_memmove
-<span class="cp-wrong">1                           pthread_getname_np | Invalid frame</span>
-2  libsystem_pthread.dylib  pthread_getname_np
-3  CrashProbe               -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4  CrashProbe iOS           -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5  UIKit                    -[UIApplication sendAction:to:from:forEvent:]
-6  UIKit                    -[UIControl sendAction:to:forEvent:]
-7  UIKit                    -[UIControl _sendActionsForEvents:withEvent:]
-8  UIKit                    -[UIControl touchesEnded:withEvent:]
-9  UIKit                    _UIGestureRecognizerUpdate
-10 UIKit                    -[UIWindow _sendGesturesForEvent:]
-11 UIKit                    -[UIWindow sendEvent:]
-12 UIKit                    -[UIApplication sendEvent:]
-13 UIKit                    _UIApplicationHandleEventQueue
-14 CoreFoundation           __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15 CoreFoundation           __CFRunLoopDoSources0
-16 CoreFoundation           __CFRunLoopRun
-17 CoreFoundation           CFRunLoopRunSpecific
-18 GraphicsServices         GSEventRunModal
-19 UIKit                    UIApplicationMain
-20 CrashProbe iOS           main (main.m:16)
-21 libdyld.dylib            start
+1  libsystem_pthread.dylib  pthread_getname_np
+2  CrashProbe               -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+3  CrashProbe iOS           -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4  UIKit                    -[UIApplication sendAction:to:from:forEvent:]
+5  UIKit                    -[UIControl sendAction:to:forEvent:]
+6  UIKit                    -[UIControl _sendActionsForEvents:withEvent:]
+7  UIKit                    -[UIControl touchesEnded:withEvent:]
+8  UIKit                    _UIGestureRecognizerUpdate
+9  UIKit                    -[UIWindow _sendGesturesForEvent:]
+10 UIKit                    -[UIWindow sendEvent:]
+11 UIKit                    -[UIApplication sendEvent:]
+12 UIKit                    _UIApplicationHandleEventQueue
+13 CoreFoundation           __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14 CoreFoundation           __CFRunLoopDoSources0
+15 CoreFoundation           __CFRunLoopRun
+16 CoreFoundation           CFRunLoopRunSpecific
+17 GraphicsServices         GSEventRunModal
+18 UIKit                    UIApplicationMain
+19 CrashProbe iOS           main (main.m:16)
+20 libdyld.dylib            start
 

--- a/ios/01/_bugsnag_armv7.crash
+++ b/ios/01/_bugsnag_armv7.crash
@@ -3,25 +3,24 @@ Exception Subtype: KERN_INVALID_ADDRESS
 Attempted to dereference garbage pointer 0x1.
 
 0  libsystem_platform.dylib _platform_memmove$VARIANT$CortexA9
-<span class="cp-wrong">1                           pthread_getname_np | Invalid frame</span>
-2  libsystem_pthread.dylib  pthread_getname_np
-3  CrashProbe               -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4  CrashProbe iOS           -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5  UIKit                    -[UIApplication sendAction:to:from:forEvent:]
-6  UIKit                    -[UIControl sendAction:to:forEvent:]
-7  UIKit                    -[UIControl _sendActionsForEvents:withEvent:]
-8  UIKit                    -[UIControl touchesEnded:withEvent:]
-9  UIKit                    _UIGestureRecognizerUpdate
-10 UIKit                    -[UIWindow _sendGesturesForEvent:]
-11 UIKit                    -[UIWindow sendEvent:]
-12 UIKit                    -[UIApplication sendEvent:]
-13 UIKit                    _UIApplicationHandleEventQueue
-14 CoreFoundation           __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15 CoreFoundation           __CFRunLoopDoSources0
-16 CoreFoundation           __CFRunLoopRun
-17 CoreFoundation           CFRunLoopRunSpecific
-18 CoreFoundation           CFRunLoopRunInMode
-19 GraphicsServices         GSEventRunModal
-20 UIKit                    UIApplicationMain
-21 CrashProbe iOS           main (main.m:16)
+1  libsystem_pthread.dylib  pthread_getname_np
+2  CrashProbe               -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+3  CrashProbe iOS           -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4  UIKit                    -[UIApplication sendAction:to:from:forEvent:]
+5  UIKit                    -[UIControl sendAction:to:forEvent:]
+6  UIKit                    -[UIControl _sendActionsForEvents:withEvent:]
+7  UIKit                    -[UIControl touchesEnded:withEvent:]
+8  UIKit                    _UIGestureRecognizerUpdate
+9  UIKit                    -[UIWindow _sendGesturesForEvent:]
+10 UIKit                    -[UIWindow sendEvent:]
+11 UIKit                    -[UIApplication sendEvent:]
+12 UIKit                    _UIApplicationHandleEventQueue
+13 CoreFoundation           __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14 CoreFoundation           __CFRunLoopDoSources0
+15 CoreFoundation           __CFRunLoopRun
+16 CoreFoundation           CFRunLoopRunSpecific
+17 CoreFoundation           CFRunLoopRunInMode
+18 GraphicsServices         GSEventRunModal
+19 UIKit                    UIApplicationMain
+20 CrashProbe iOS           main (main.m:16)
 

--- a/ios/01/data.json
+++ b/ios/01/data.json
@@ -26,8 +26,8 @@
       "arm64": "incomplete"
     },
     "Bugsnag": {
-      "armv7": "incomplete",
-      "arm64": "incomplete"
+      "armv7": "complete",
+      "arm64": "complete"
     },
     "Crittercism": {
       "armv7": "wrong",

--- a/ios/11/_bugsnag_arm64.crash
+++ b/ios/11/_bugsnag_arm64.crash
@@ -1,24 +1,23 @@
 Exception Type:  EXC_BAD_ACCESS (SIGBUS)
-Attempted to dereference garbage pointer 0x104048000.
+Attempted to dereference garbage pointer 0x103bb0000.
 
 0  CrashProbe       -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
-<span class="cp-wrong">1                   -[CRLCrashGarbage crash] | Invalid frame</span>
-2  CrashProbe iOS   -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3  UIKit            -[UIApplication sendAction:to:from:forEvent:]
-4  UIKit            -[UIControl sendAction:to:forEvent:]
-5  UIKit            -[UIControl _sendActionsForEvents:withEvent:]
-6  UIKit            -[UIControl touchesEnded:withEvent:]
-7  UIKit            _UIGestureRecognizerUpdate
-8  UIKit            -[UIWindow _sendGesturesForEvent:]
-9  UIKit            -[UIWindow sendEvent:]
-10 UIKit            -[UIApplication sendEvent:]
-11 UIKit            _UIApplicationHandleEventQueue
-12 CoreFoundation   __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13 CoreFoundation   __CFRunLoopDoSources0
-14 CoreFoundation   __CFRunLoopRun
-15 CoreFoundation   CFRunLoopRunSpecific
-16 GraphicsServices GSEventRunModal
-17 UIKit            UIApplicationMain
-18 CrashProbe iOS   main (main.m:16)
-19 libdyld.dylib    start
+1  CrashProbe iOS   -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2  UIKit            -[UIApplication sendAction:to:from:forEvent:]
+3  UIKit            -[UIControl sendAction:to:forEvent:]
+4  UIKit            -[UIControl _sendActionsForEvents:withEvent:]
+5  UIKit            -[UIControl touchesEnded:withEvent:]
+6  UIKit            _UIGestureRecognizerUpdate
+7  UIKit            -[UIWindow _sendGesturesForEvent:]
+8  UIKit            -[UIWindow sendEvent:]
+9  UIKit            -[UIApplication sendEvent:]
+10 UIKit            _UIApplicationHandleEventQueue
+11 CoreFoundation   __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12 CoreFoundation   __CFRunLoopDoSources0
+13 CoreFoundation   __CFRunLoopRun
+14 CoreFoundation   CFRunLoopRunSpecific
+15 GraphicsServices GSEventRunModal
+16 UIKit            UIApplicationMain
+17 CrashProbe iOS   main (main.m:16)
+18 libdyld.dylib    start
 

--- a/ios/11/data.json
+++ b/ios/11/data.json
@@ -28,7 +28,7 @@
     },
     "Bugsnag": {
       "armv7": "complete",
-      "arm64": "incomplete"
+      "arm64": "complete"
     },
     "Crittercism": {
       "armv7": "wrong",

--- a/ios/16/_bugsnag_armv7.crash
+++ b/ios/16/_bugsnag_armv7.crash
@@ -1,1 +1,39 @@
-<span class="cp-wrong">App locks up.</span>
+Exception Type:  EXC_CRASH (SIGABRT)
+
+0  libsystem_kernel.dylib  __pthread_kill
+1  libsystem_pthread.dylib pthread_kill
+2  libsystem_c.dylib       abort
+3  libsystem_malloc.dylib  szone_error
+4  libsystem_malloc.dylib  free_list_checksum_botch
+5  libsystem_malloc.dylib  tiny_malloc_from_free_list
+6  libsystem_malloc.dylib  szone_malloc_should_clear
+7  libsystem_malloc.dylib  malloc_zone_malloc
+8  libsystem_malloc.dylib  malloc
+9  libsystem_c.dylib       _vasprintf
+10 libsystem_c.dylib       vasprintf_l
+11 libsystem_c.dylib       asprintf
+12 CoreFoundation          __CFLogCString
+13 CoreFoundation          _CFLogvEx2
+14 CoreFoundation          _CFLogvEx3
+15 Foundation              _NSLogv
+16 Foundation              NSLog
+17 CrashProbe              -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+18 CrashProbe iOS          -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+19 UIKit                   -[UIApplication sendAction:to:from:forEvent:]
+20 UIKit                   -[UIControl sendAction:to:forEvent:]
+21 UIKit                   -[UIControl _sendActionsForEvents:withEvent:]
+22 UIKit                   -[UIControl touchesEnded:withEvent:]
+23 UIKit                   _UIGestureRecognizerUpdate
+24 UIKit                   -[UIWindow _sendGesturesForEvent:]
+25 UIKit                   -[UIWindow sendEvent:]
+26 UIKit                   -[UIApplication sendEvent:]
+27 UIKit                   _UIApplicationHandleEventQueue
+28 CoreFoundation          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+29 CoreFoundation          __CFRunLoopDoSources0
+30 CoreFoundation          __CFRunLoopRun
+31 CoreFoundation          CFRunLoopRunSpecific
+32 CoreFoundation          CFRunLoopRunInMode
+33 GraphicsServices        GSEventRunModal
+34 UIKit                   UIApplicationMain
+35 CrashProbe iOS          main (main.m:16)
+

--- a/ios/16/data.json
+++ b/ios/16/data.json
@@ -26,7 +26,7 @@
       "arm64": "wrong"
     },
     "Bugsnag": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "complete"
     },
     "Crittercism": {

--- a/ios/19/_bugsnag_arm64.crash
+++ b/ios/19/_bugsnag_arm64.crash
@@ -2,23 +2,22 @@ Exception Type:  EXC_BAD_ACCESS (SIGBUS)
 Attempted to dereference null pointer.
 
 0  CrashProbe       -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-<span class="cp-wrong">1                   -[CRLCrashOverwriteLinkRegister crash] | Invalid frame</span>
-2  CrashProbe iOS   -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3  UIKit            -[UIApplication sendAction:to:from:forEvent:]
-4  UIKit            -[UIControl sendAction:to:forEvent:]
-5  UIKit            -[UIControl _sendActionsForEvents:withEvent:]
-6  UIKit            -[UIControl touchesEnded:withEvent:]
-7  UIKit            _UIGestureRecognizerUpdate
-8  UIKit            -[UIWindow _sendGesturesForEvent:]
-9  UIKit            -[UIWindow sendEvent:]
-10 UIKit            -[UIApplication sendEvent:]
-11 UIKit            _UIApplicationHandleEventQueue
-12 CoreFoundation   __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13 CoreFoundation   __CFRunLoopDoSources0
-14 CoreFoundation   __CFRunLoopRun
-15 CoreFoundation   CFRunLoopRunSpecific
-16 GraphicsServices GSEventRunModal
-17 UIKit            UIApplicationMain
-18 CrashProbe iOS   main (main.m:16)
-19 libdyld.dylib    start
+1  CrashProbe iOS   -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2  UIKit            -[UIApplication sendAction:to:from:forEvent:]
+3  UIKit            -[UIControl sendAction:to:forEvent:]
+4  UIKit            -[UIControl _sendActionsForEvents:withEvent:]
+5  UIKit            -[UIControl touchesEnded:withEvent:]
+6  UIKit            _UIGestureRecognizerUpdate
+7  UIKit            -[UIWindow _sendGesturesForEvent:]
+8  UIKit            -[UIWindow sendEvent:]
+9  UIKit            -[UIApplication sendEvent:]
+10 UIKit            _UIApplicationHandleEventQueue
+11 CoreFoundation   __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12 CoreFoundation   __CFRunLoopDoSources0
+13 CoreFoundation   __CFRunLoopRun
+14 CoreFoundation   CFRunLoopRunSpecific
+15 GraphicsServices GSEventRunModal
+16 UIKit            UIApplicationMain
+17 CrashProbe iOS   main (main.m:16)
+18 libdyld.dylib    start
 

--- a/ios/19/_bugsnag_armv7.crash
+++ b/ios/19/_bugsnag_armv7.crash
@@ -3,23 +3,22 @@ Exception Subtype: KERN_INVALID_ADDRESS
 Attempted to dereference null pointer.
 
 0  CrashProbe       -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-<span class="cp-wrong">1                   -[CRLCrashOverwriteLinkRegister crash] | Invalid frame</span>
-2  CrashProbe iOS   -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3  UIKit            -[UIApplication sendAction:to:from:forEvent:]
-4  UIKit            -[UIControl sendAction:to:forEvent:]
-5  UIKit            -[UIControl _sendActionsForEvents:withEvent:]
-6  UIKit            -[UIControl touchesEnded:withEvent:]
-7  UIKit            _UIGestureRecognizerUpdate
-8  UIKit            -[UIWindow _sendGesturesForEvent:]
-9  UIKit            -[UIWindow sendEvent:]
-10 UIKit            -[UIApplication sendEvent:]
-11 UIKit            _UIApplicationHandleEventQueue
-12 CoreFoundation   __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13 CoreFoundation   __CFRunLoopDoSources0
-14 CoreFoundation   __CFRunLoopRun
-15 CoreFoundation   CFRunLoopRunSpecific
-16 CoreFoundation   CFRunLoopRunInMode
-17 GraphicsServices GSEventRunModal
-18 UIKit            UIApplicationMain
-19 CrashProbe iOS   main (main.m:16)
+1  CrashProbe iOS   -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2  UIKit            -[UIApplication sendAction:to:from:forEvent:]
+3  UIKit            -[UIControl sendAction:to:forEvent:]
+4  UIKit            -[UIControl _sendActionsForEvents:withEvent:]
+5  UIKit            -[UIControl touchesEnded:withEvent:]
+6  UIKit            _UIGestureRecognizerUpdate
+7  UIKit            -[UIWindow _sendGesturesForEvent:]
+8  UIKit            -[UIWindow sendEvent:]
+9  UIKit            -[UIApplication sendEvent:]
+10 UIKit            _UIApplicationHandleEventQueue
+11 CoreFoundation   __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12 CoreFoundation   __CFRunLoopDoSources0
+13 CoreFoundation   __CFRunLoopRun
+14 CoreFoundation   CFRunLoopRunSpecific
+15 CoreFoundation   CFRunLoopRunInMode
+16 GraphicsServices GSEventRunModal
+17 UIKit            UIApplicationMain
+18 CrashProbe iOS   main (main.m:16)
 

--- a/ios/19/data.json
+++ b/ios/19/data.json
@@ -26,8 +26,8 @@
       "arm64": "incomplete"
     },
     "Bugsnag": {
-      "armv7": "incomplete",
-      "arm64": "incomplete"
+      "armv7": "complete",
+      "arm64": "complete"
     },
     "Crittercism": {
       "armv7": "wrong",


### PR DESCRIPTION
Provider name: Bugsnag
Repository URL: https://github.com/bugsnag/bugsnag-cocoa-crashprobe

Date of testing: 02/16/2016
SDK Version:
- Mac: 5.0.0
- iOS: 5.0.0

Test environment per architecture:
- MacBook Pro (Retina, 13-inch, Early 2015), OS X 10.11.3 (15D21)
- iPhone 6, iOS 9.2.1
- iPod Touch 5th gen (A1421), iOS 9.2.1
