### PR TITLE
Raygun tests from 09/13/2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The test case data providers per service:
 - Crittercism: [Bit Stadium GmbH](http://hockeyapp.net/)
 - HockeyApp: [Bit Stadium GmbH](http://hockeyapp.net/)
 - New Relic: [Bit Stadium GmbH](http://hockeyapp.net/)
-- Raygun: [Bit Stadium GmbH](http://hockeyapp.net/)
+- Raygun: [Raygun Limited](https://raygun.com)
 - Splunk MINT Express: [Bit Stadium GmbH](http://hockeyapp.net/)
 
 # License

--- a/ios/01/_raygun_arm64.crash
+++ b/ios/01/_raygun_arm64.crash
@@ -1,21 +1,22 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_platform.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_pthread.dylib | Missing class, and method</span> 
-<span class="cp-wrong">-[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:45) | Wrong line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
+0   libsystem_platform.dylib            0x000000018317a334 _platform_memmove + 324
+1   libsystem_pthread.dylib             0x0000000183184ad8 pthread_getname_np + 108
+2   libsystem_pthread.dylib             0x0000000183184ad8 pthread_getname_np + 108
+3   CrashLibiOS                         0x00000001000c34b4 -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                       0x000000010006c898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+6   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+7   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+8   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+9   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+10  UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+11  UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+12  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+13  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+14  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+15  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+16  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+17  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+18  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+19  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+20  CrashProbeiOS                       0x000000010006b984 main (main.m:16)
+21  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/01/_raygun_armv7.crash
+++ b/ios/01/_raygun_armv7.crash
@@ -1,25 +1,23 @@
-NotProvided
-
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_platform.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_pthread.dylib | Missing class, and method</span> 
-<span class="cp-wrong">-[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:45) | Wrong line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
-    
+0   libsystem_platform.dylib            0x24f4a1a4 _platform_memmove$VARIANT$CortexA9 + 104
+1   libsystem_pthread.dylib             0x24f503c9 pthread_getname_np + 72
+2   libsystem_pthread.dylib             0x24f503c9 pthread_getname_np + 72
+3   CrashLibiOS                         0x001b6877 -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                       0x00074b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+6   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+7   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+8   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+9   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+10  UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+11  UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+12  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+13  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+14  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+15  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+16  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+17  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+18  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+19  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+20  UIKit                               0x297ff189 UIApplicationMain + 144
+21  CrashProbeiOS                       0x00073ee7 main (main.m:16)
+22  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/01/data.json
+++ b/ios/01/data.json
@@ -22,7 +22,7 @@
       "arm64": "complete"
     },
     "Raygun": {
-      "armv7": "incomplete",
+      "armv7": "complete",
       "arm64": "incomplete"
     },
     "Bugsnag": {

--- a/ios/01/data.json
+++ b/ios/01/data.json
@@ -23,7 +23,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "incomplete"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/02/_raygun_arm64.crash
+++ b/ios/02/_raygun_arm64.crash
@@ -1,16 +1,17 @@
 <span class="cp-wrong">Missing exception details</span>
 
 <span class="cp-wrong">Missing frame that shows where the crash occured</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_kernel.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_c.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
+0   libsystem_kernel.dylib              0x00000001830b811c __pthread_kill + 8
+1   libsystem_pthread.dylib             0x0000000183184ef8 pthread_kill + 112
+2   libsystem_c.dylib                   0x0000000183029dc8 abort + 140
+3   libc++abi.dylib                     0x0000000182b5d3f4 abort_message + 132
+4   libc++abi.dylib                     0x0000000182b79e98 default_terminate_handler() + 304
+5   libobjc.A.dylib                     0x0000000182b84264 _objc_terminate() + 152
+6   libc++abi.dylib                     0x0000000182b76f44 std::__terminate(void (*)()) + 16
+7   libc++abi.dylib                     0x0000000182b76b10 __cxa_rethrow + 144
+8   libobjc.A.dylib                     0x0000000182b84120 objc_exception_rethrow + 44
+9   CoreFoundation                      0x00000001833fccf8 CFRunLoopRunSpecific + 552
+10  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+11  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+12  CrashProbeiOS                       0x00000001000b7984 main (main.m:16)
+13  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/02/_raygun_armv7.crash
+++ b/ios/02/_raygun_armv7.crash
@@ -1,17 +1,18 @@
 <span class="cp-wrong">Missing exception details</span>
 
 <span class="cp-wrong">Missing frame that shows where the crash occured</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_kernel.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_c.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libc++abi.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
+0   libsystem_kernel.dylib              0x24ea6c5c __pthread_kill + 8
+1   libsystem_pthread.dylib             0x24f50733 pthread_kill + 62
+2   libsystem_c.dylib                   0x24e3b0ad abort + 108
+3   libc++abi.dylib                     0x24992ae5 abort_message + 108
+4   libc++abi.dylib                     0x249ab69f default_terminate_handler() + 266
+5   libobjc.A.dylib                     0x249b70d5 _objc_terminate() + 228
+6   libc++abi.dylib                     0x249a8e17 std::__terminate(void (*)()) + 78
+7   libc++abi.dylib                     0x249a88f9 __cxa_rethrow + 100
+8   libobjc.A.dylib                     0x249b6f5f objc_exception_rethrow + 42
+9   CoreFoundation                      0x2512b2af CFRunLoopRunSpecific + 654
+10  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+11  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+12  UIKit                               0x297ff189 UIApplicationMain + 144
+13  CrashProbeiOS                       0x00071ee7 main (main.m:16)
+14  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/03/_raygun_arm64.crash
+++ b/ios/03/_raygun_arm64.crash
@@ -1,23 +1,23 @@
 An uncaught exception! SCREAM.
 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found | Missing class, method, filename, and line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
+0   CoreFoundation                      0x000000018351edb0 __exceptionPreprocess + 124
+1   libobjc.A.dylib                     0x0000000182b83f80 objc_exception_throw + 56
+2   CrashLibiOS                         0x000000010012770c -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                       0x00000001000d8898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+5   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+6   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+7   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+8   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+9   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+10  UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+11  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+12  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+13  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+14  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+15  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+16  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+17  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+18  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+19  CrashProbeiOS                       0x00000001000d7984 main (main.m:16)
+20  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/03/_raygun_armv7.crash
+++ b/ios/03/_raygun_armv7.crash
@@ -1,24 +1,24 @@
 An uncaught exception! SCREAM.
 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found | Missing class, method, filename, and line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
+0   CoreFoundation                      0x2521b91b __exceptionPreprocess + 127
+1   libobjc.A.dylib                     0x249b6e17 objc_exception_throw + 38
+2   CrashLibiOS                         0x00216a8b -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                       0x000d4b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+5   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+6   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+7   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+8   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+9   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+10  UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+11  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+12  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+13  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+14  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+15  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+16  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+17  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+18  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+19  UIKit                               0x297ff189 UIApplicationMain + 144
+20  CrashProbeiOS                       0x000d3ee7 main (main.m:16)
+21  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/03/data.json
+++ b/ios/03/data.json
@@ -23,7 +23,7 @@
       "arm64": "wrong"
     },
     "Raygun": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/03/data.json
+++ b/ios/03/data.json
@@ -24,7 +24,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "wrong"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/04/_raygun_arm64.crash
+++ b/ios/04/_raygun_arm64.crash
@@ -1,26 +1,27 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/Foundation.framework/Foundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/Foundation.framework/Foundation | Missing class, and method</span> 
-<span class="cp-wrong">-[CRLCrashNSLog crash] (CRLCrashNSLog.m:42) | Wrong line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
-    
+0   libobjc.A.dylib                     0x0000000182b95b88 objc_msgSend + 8
+1   Foundation                          0x0000000183ef1e20 _NSDescriptionWithStringProxyFunc + 64
+2   CoreFoundation                      0x00000001834e832c __CFStringAppendFormatCore + 7824
+3   CoreFoundation                      0x00000001834e6464 _CFStringCreateWithFormatAndArgumentsAux2 + 244
+4   CoreFoundation                      0x0000000183504bc4 _CFLogvEx2 + 152
+5   CoreFoundation                      0x00000001835050c4 _CFLogvEx3 + 156
+6   Foundation                          0x0000000183eddfe4 _NSLogv + 132
+7   Foundation                          0x0000000183e12904 NSLog + 32
+8   CrashLibiOS                         0x000000010014b7ac -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+9   CrashProbeiOS                       0x00000001000e8898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+11  UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+12  UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+13  UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+14  UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+15  UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+16  UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+17  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+18  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+19  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+20  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+21  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+22  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+23  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+24  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+25  CrashProbeiOS                       0x00000001000e7984 main (main.m:16)
+26  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/04/_raygun_armv7.crash
+++ b/ios/04/_raygun_armv7.crash
@@ -1,27 +1,28 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/Foundation.framework/Foundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/Foundation.framework/Foundation | Missing class, and method</span> 
-<span class="cp-wrong">-[CRLCrashNSLog crash] (CRLCrashNSLog.m:42) | Wrong line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span> 
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span> 
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span> 
+0   libobjc.A.dylib                     0x249c3a62 objc_msgSend + 2
+1   Foundation                          0x25a436e9 _NSDescriptionWithStringProxyFunc + 48
+2   CoreFoundation                      0x251ed6b7 __CFStringAppendFormatCore + 6726
+3   CoreFoundation                      0x251ebc51 _CFStringCreateWithFormatAndArgumentsAux2 + 80
+4   CoreFoundation                      0x25204b51 _CFLogvEx2 + 96
+5   CoreFoundation                      0x25204fb1 _CFLogvEx3 + 120
+6   Foundation                          0x25a3262f _NSLogv + 122
+7   Foundation                          0x2597903d NSLog + 28
+8   CrashLibiOS                         0x001aeae7 -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+9   CrashProbeiOS                       0x0006cb59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+11  UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+12  UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+13  UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+14  UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+15  UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+16  UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+17  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+18  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+19  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+20  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+21  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+22  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+23  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+24  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+25  UIKit                               0x297ff189 UIApplicationMain + 144
+26  CrashProbeiOS                       0x0006bee7 main (main.m:16)
+27  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/04/data.json
+++ b/ios/04/data.json
@@ -22,7 +22,7 @@
       "arm64": "complete"
     },
     "Raygun": {
-      "armv7": "incomplete",
+      "armv7": "complete",
       "arm64": "incomplete"
     },
     "Bugsnag": {

--- a/ios/04/data.json
+++ b/ios/04/data.json
@@ -23,7 +23,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "incomplete"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/05/_raygun_arm64.crash
+++ b/ios/05/_raygun_arm64.crash
@@ -1,20 +1,20 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">Missing frame that shows where the crash occured</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+0   libobjc.A.dylib                     0x0000000182b95b90 objc_msgSend + 16
+1   CrashLibiOS                         0x000000010013f8ec -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                       0x00000001000e8898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+4   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+5   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+6   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+7   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+8   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+9   UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+10  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+11  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+12  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+13  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+14  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+15  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+16  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+17  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+18  CrashProbeiOS                       0x00000001000e7984 main (main.m:16)
+19  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/05/_raygun_armv7.crash
+++ b/ios/05/_raygun_armv7.crash
@@ -1,23 +1,21 @@
-NotProvided
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">Missing frame that shows where the crash occured</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   libobjc.A.dylib                     0x249c3a66 objc_msgSend + 6
+1   CrashLibiOS                         0x00161bfb -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                       0x0001fb59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+4   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+5   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+6   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+7   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+8   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+9   UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+10  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+11  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+12  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+13  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+14  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+15  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+16  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+17  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+18  UIKit                               0x297ff189 UIApplicationMain + 144
+19  CrashProbeiOS                       0x0001eee7 main (main.m:16)
+20  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/05/data.json
+++ b/ios/05/data.json
@@ -22,7 +22,7 @@
       "arm64": "complete"
     },
     "Raygun": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/05/data.json
+++ b/ios/05/data.json
@@ -23,7 +23,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "wrong"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/06/_raygun_arm64.crash
+++ b/ios/06/_raygun_arm64.crash
@@ -1,21 +1,21 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">Missing frame that shows where the crash occured</span>
--[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+0   libobjc.A.dylib                     0x0000000182b95b90 objc_msgSend + 16
+1   CrashLibiOS                         0x0000000100147a60 __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                         0x00000001001479f8 -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                       0x00000001000ec898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+5   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+6   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+7   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+8   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+9   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+10  UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+11  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+12  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+13  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+14  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+15  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+16  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+17  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+18  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+19  CrashProbeiOS                       0x00000001000eb984 main (main.m:16)
+20  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/06/_raygun_armv7.crash
+++ b/ios/06/_raygun_armv7.crash
@@ -1,24 +1,22 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">Missing frame that shows where the crash occured</span>
-<span class="cp-wrong">No matching symbols found | Missing class, method, filename, and line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   libobjc.A.dylib                     0x249c3a66 objc_msgSend + 6
+1   CrashLibiOS                         0x001ebd1d __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                         0x001ebcc1 -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                       0x000a9b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+5   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+6   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+7   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+8   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+9   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+10  UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+11  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+12  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+13  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+14  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+15  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+16  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+17  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+18  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+19  UIKit                               0x297ff189 UIApplicationMain + 144
+20  CrashProbeiOS                       0x000a8ee7 main (main.m:16)
+21  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/06/data.json
+++ b/ios/06/data.json
@@ -24,7 +24,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "wrong"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/06/data.json
+++ b/ios/06/data.json
@@ -23,7 +23,7 @@
       "arm64": "incomplete"
     },
     "Raygun": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/07/_raygun_arm64.crash
+++ b/ios/07/_raygun_arm64.crash
@@ -1,18 +1,18 @@
--[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x00000001000efb00 -[CRLCrashROPage crash] (CRLCrashROPage.m:39) | Wrong line number</span>
+1   CrashProbeiOS                       0x00000001000a0898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+7   UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+8   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+9   UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+10  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+11  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+12  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+13  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+14  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+15  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+16  CrashProbeiOS                       0x000000010009f984 main (main.m:16)
+17  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/07/_raygun_armv7.crash
+++ b/ios/07/_raygun_armv7.crash
@@ -1,21 +1,20 @@
--[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+<span class="cp-wrong">0   CrashLibiOS                         0x001a8d7e -[CRLCrashROPage crash] (CRLCrashROPage.m:39) | Wrong line number</span>
+1   CrashProbeiOS                       0x00066b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+7   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+8   UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+9   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+10  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+11  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+12  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+13  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+14  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+15  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+16  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+17  UIKit                               0x297ff189 UIApplicationMain + 144
+18  CrashProbeiOS                       0x00065ee7 main (main.m:16)
+19  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/08/_raygun_arm64.crash
+++ b/ios/08/_raygun_arm64.crash
@@ -1,19 +1,19 @@
-<span class="cp-wrong">-[CRLCrashPrivInst desc] (CRLCrashPrivInst.m:52) | Wrong method</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x0000000100133b8c -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:35) | Wrong line number</span>
+1   CrashProbeiOS                       0x00000001000dc898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+7   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+8   UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+9   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+10  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+11  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+12  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+13  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+14  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+15  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+16  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+17  CrashProbeiOS                       0x00000001000db984 main (main.m:16)
+18  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/08/_raygun_armv7.crash
+++ b/ios/08/_raygun_armv7.crash
@@ -1,21 +1,20 @@
-<span class="cp-wrong">-[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42) | Wrong method</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+<span class="cp-wrong">0   CrashLibiOS                         0x001b8dcc -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:35) | Wrong line number</span>
+1   CrashProbeiOS                       0x00076b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+7   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+8   UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+9   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+10  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+11  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+12  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+13  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+14  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+15  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+16  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+17  UIKit                               0x297ff189 UIApplicationMain + 144
+18  CrashProbeiOS                       0x00075ee7 main (main.m:16)
+19  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/09/_raygun_arm64.crash
+++ b/ios/09/_raygun_arm64.crash
@@ -1,19 +1,19 @@
-<span class="cp-wrong">-[CRLCrashUndefInst desc] (CRLCrashUndefInst.m:50) | Wrong method</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x00000001000dbc18 -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:35) | Wrong line number</span>
+1   CrashProbeiOS                       0x0000000100078898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+7   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+8   UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+9   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+10  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+11  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+12  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+13  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+14  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+15  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+16  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+17  CrashProbeiOS                       0x0000000100077984 main (main.m:16)
+18  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/09/_raygun_armv7.crash
+++ b/ios/09/_raygun_armv7.crash
@@ -1,21 +1,19 @@
-<span class="cp-wrong">-[CRLCrashUndefInst desc] (CRLCrashUndefInst.m:42) | Wrong method</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x00201e18 -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:35) | Wrong line number</span>
+1   CrashProbeiOS                       0x000bfb59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+7   UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+8   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+9   UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+10  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+11  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+12  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+13  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+14  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+15  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+16  UIKit                               0x297ff189 UIApplicationMain + 144
+17  CrashProbeiOS                       0x000beee7 main (main.m:16)
+18  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/10/_raygun_arm64.crash
+++ b/ios/10/_raygun_arm64.crash
@@ -1,19 +1,18 @@
--[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x0000000100147ca8 -[CRLCrashNULL crash] (CRLCrashNULL.m:34) | Wrong line number</span>
+1   CrashProbeiOS                       0x00000001000ec898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+7   UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+8   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+9   UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+10  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+11  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+12  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+13  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+14  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+15  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+16  CrashProbeiOS                       0x00000001000eb984 main (main.m:16)
+17  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/10/_raygun_armv7.crash
+++ b/ios/10/_raygun_armv7.crash
@@ -1,22 +1,20 @@
--[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+<span class="cp-wrong">0   CrashLibiOS                         0x001a9e68 -[CRLCrashNULL crash] (CRLCrashNULL.m:34) | Wrong line number</span>
+1   CrashProbeiOS                       0x00067b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+7   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+8   UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+9   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+10  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+11  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+12  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+13  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+14  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+15  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+16  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+17  UIKit                               0x297ff189 UIApplicationMain + 144
+18  CrashProbeiOS                       0x00066ee7 main (main.m:16)
+19  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/11/_raygun_arm64.crash
+++ b/ios/11/_raygun_arm64.crash
@@ -1,19 +1,20 @@
--[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+0   CrashLibiOS                         0x0000000100113d80 -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
+<span class="cp-wrong">1   CrashLibiOS                         0x0000000100113d7c -[CRLCrashGarbage crash] (CRLCrashGarbage.m:41) | Invalid frame</span>
+2   CrashProbeiOS                       0x00000001000ac898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+4   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+5   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+6   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+7   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+8   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+9   UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+10  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+11  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+12  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+13  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+14  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+15  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+16  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+17  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+18  CrashProbeiOS                       0x00000001000ab984 main (main.m:16)
+19  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/11/_raygun_armv7.crash
+++ b/ios/11/_raygun_armv7.crash
@@ -1,22 +1,21 @@
--[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   CrashLibiOS                         0x001bbeec -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
+1   libsystem_kernel.dylib              0x24e9341f munmap + 18
+2   CrashProbeiOS                       0x00079b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+4   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+5   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+6   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+7   UIKit                               0x29787f25 _UIGestureRecognizerUpdate + 10852
+8   UIKit                               0x297c6ec9 -[UIWindow _sendGesturesForEvent:] + 904
+9   UIKit                               0x297c667b -[UIWindow sendEvent:] + 622
+10  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+11  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+12  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+13  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+14  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+15  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+16  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+17  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+18  UIKit                               0x297ff189 UIApplicationMain + 144
+19  CrashProbeiOS                       0x00078ee7 main (main.m:16)
+20  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/11/data.json
+++ b/ios/11/data.json
@@ -23,7 +23,7 @@
       "arm64": "complete"
     },
     "Raygun": {
-      "armv7": "incomplete",
+      "armv7": "complete",
       "arm64": "incomplete"
     },
     "Bugsnag": {

--- a/ios/12/_raygun_arm64.crash
+++ b/ios/12/_raygun_arm64.crash
@@ -1,19 +1,18 @@
-<span class="cp-wrong">No matching symbols found | Missing class, method, filename, and line number</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x000000010008be14 -[CRLCrashNXPage crash] + 0 | Missing filename, and line number</span>
+1   CrashProbeiOS                       0x0000000100034898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+7   UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+8   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+9   UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+10  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+11  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+12  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+13  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+14  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+15  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+16  CrashProbeiOS                       0x0000000100033984 main (main.m:16)
+17  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/12/_raygun_armv7.crash
+++ b/ios/12/_raygun_armv7.crash
@@ -1,22 +1,19 @@
-<span class="cp-wrong">No matching symbols found | Missing class, method, filename, and line number</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+<span class="cp-wrong">0   CrashLibiOS                         0x001bcf3a -[CRLCrashNXPage crash] + 0 | Missing filename, and line number</span>
+1   CrashProbeiOS                       0x0007ab59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+7   UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+8   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+9   UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+10  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+11  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+12  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+13  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+14  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+15  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+16  UIKit                               0x297ff189 UIApplicationMain + 144
+17  CrashProbeiOS                       0x00079ee7 main (main.m:16)
+18  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/12/data.json
+++ b/ios/12/data.json
@@ -23,7 +23,7 @@
     },
     "Raygun": {
       "armv7": "incomplete",
-      "arm64": "wrong"
+      "arm64": "incomplete"
     },
     "Bugsnag": {
       "armv7": "incomplete",

--- a/ios/12/data.json
+++ b/ios/12/data.json
@@ -22,7 +22,7 @@
       "arm64": "incomplete"
     },
     "Raygun": {
-      "armv7": "wrong",
+      "armv7": "incomplete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/14/_raygun_arm64.crash
+++ b/ios/14/_raygun_arm64.crash
@@ -1,19 +1,18 @@
-<span class="cp-wrong">-[CRLCrashTrap desc] (CRLCrashTrap.m:37) | Wrong method</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x00000001000a7f48 -[CRLCrashTrap crash] (CRLCrashTrap.m:35) | Wrong line number</span>
+1   CrashProbeiOS                       0x0000000100058898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+7   UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+8   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+9   UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+10  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+11  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+12  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+13  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+14  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+15  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+16  CrashProbeiOS                       0x0000000100057984 main (main.m:16)
+17  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/14/_raygun_armv7.crash
+++ b/ios/14/_raygun_armv7.crash
@@ -1,22 +1,19 @@
-<span class="cp-wrong">-[CRLCrashTrap desc] (CRLCrashTrap.m:37) | Wrong method</span>
-<span class="cp-wrong">Missing frame</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+<span class="cp-wrong">0   CrashLibiOS                         0x0014eff0 -[CRLCrashTrap crash] (CRLCrashTrap.m:35) | Wrong line number</span>
+1   CrashProbeiOS                       0x0000cb59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+7   UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+8   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+9   UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+10  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+11  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+12  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+13  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+14  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+15  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+16  UIKit                               0x297ff189 UIApplicationMain + 144
+17  CrashProbeiOS                       0x0000bee7 main (main.m:16)
+18  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/15/_raygun_arm64.crash
+++ b/ios/15/_raygun_arm64.crash
@@ -1,21 +1,21 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_kernel.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_c.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found | Missing class, method, filename, and line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+0   libsystem_kernel.dylib              0x00000001830b811c __pthread_kill + 8
+1   libsystem_pthread.dylib             0x0000000183184ef8 pthread_kill + 112
+2   libsystem_c.dylib                   0x0000000183029dc8 abort + 140
+3   CrashLibiOS                         0x0000000100073fdc -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                       0x0000000100024898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+6   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+7   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+8   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+9   UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+10  UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+11  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+12  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+13  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+14  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+15  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+16  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+17  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+18  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+19  CrashProbeiOS                       0x0000000100023984 main (main.m:16)
+20  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/15/_raygun_armv7.crash
+++ b/ios/15/_raygun_armv7.crash
@@ -1,24 +1,22 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_kernel.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_c.dylib | Missing class, and method</span>
-<span class="cp-wrong">-[CRLCrashCorruptMalloc category] (CRLCrashCorruptMalloc.m:0) | Wrong class, method, filename, and line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   libsystem_kernel.dylib              0x24ea6c5c __pthread_kill + 8
+1   libsystem_pthread.dylib             0x24f50733 pthread_kill + 62
+2   libsystem_c.dylib                   0x24e3b0ad abort + 108
+3   CrashLibiOS                         0x001b0043 -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                       0x0006db59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+6   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+7   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+8   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+9   UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+10  UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+11  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+12  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+13  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+14  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+15  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+16  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+17  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+18  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+19  UIKit                               0x297ff189 UIApplicationMain + 144
+20  CrashProbeiOS                       0x0006cee7 main (main.m:16)
+21  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/15/data.json
+++ b/ios/15/data.json
@@ -18,12 +18,12 @@
       "arm64": "complete"
     },
     "Crashlytics": {
-      "armv7": "complete",
+      "armv7": "wrong",
       "arm64": "wrong"
     },
     "Raygun": {
-      "armv7": "wrong",
-      "arm64": "wrong"
+      "armv7": "complete",
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/15/data.json
+++ b/ios/15/data.json
@@ -18,7 +18,7 @@
       "arm64": "complete"
     },
     "Crashlytics": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "wrong"
     },
     "Raygun": {

--- a/ios/16/_raygun_arm64.crash
+++ b/ios/16/_raygun_arm64.crash
@@ -1,1 +1,36 @@
-<span class="cp-wrong">Missing stack trace</span>
+0   libsystem_kernel.dylib              0x00000001830b811c __pthread_kill + 8
+1   libsystem_pthread.dylib             0x0000000183184ef8 pthread_kill + 112
+2   libsystem_c.dylib                   0x0000000183029dc8 abort + 140
+3   libsystem_malloc.dylib              0x00000001830ecd24 szone_error + 440
+4   libsystem_malloc.dylib              0x00000001830ecd48 free_list_checksum_botch + 36
+5   libsystem_malloc.dylib              0x00000001830e2b0c tiny_malloc_from_free_list + 328
+6   libsystem_malloc.dylib              0x00000001830e15ac szone_malloc_should_clear + 268
+7   libsystem_malloc.dylib              0x00000001830e5930 malloc_zone_calloc + 124
+8   libsystem_malloc.dylib              0x00000001830e5890 calloc + 60
+9   libsystem_asl.dylib                 0x0000000182faef70 asl_string_new + 36
+10  libsystem_asl.dylib                 0x0000000182faede8 asl_msg_to_string_raw + 72
+11  libsystem_asl.dylib                 0x0000000182fae8d0 _asl_send_message + 832
+12  libsystem_asl.dylib                 0x0000000182fae4f0 asl_send + 12
+13  CoreFoundation                      0x0000000183504ecc __CFLogCString + 572
+14  CoreFoundation                      0x0000000183504c5c _CFLogvEx2 + 304
+15  CoreFoundation                      0x00000001835050c4 _CFLogvEx3 + 156
+16  Foundation                          0x0000000183eddfe4 _NSLogv + 132
+17  Foundation                          0x0000000183e12904 NSLog + 32
+18  CrashLibiOS                         0x000000010009c0a4 -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+19  CrashProbeiOS                       0x0000000100038898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+20  UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+21  UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+22  UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+23  UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+24  UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+25  UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+26  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+27  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+28  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+29  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+30  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+31  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+32  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+33  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+34  CrashProbeiOS                       0x0000000100037984 main (main.m:16)
+35  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/16/_raygun_armv7.crash
+++ b/ios/16/_raygun_armv7.crash
@@ -1,31 +1,40 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_notify.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_notify.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_asl.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_asl.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libsystem_asl.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/Foundation.framework/Foundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/Foundation.framework/Foundation | Missing class, and method</span>
-<span class="cp-wrong">-[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:47) | Wrong line number</span>
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   libsystem_kernel.dylib              0x24ea6c5c __pthread_kill + 8
+1   libsystem_pthread.dylib             0x24f50733 pthread_kill + 62
+2   libsystem_c.dylib                   0x24e3b0ad abort + 108
+3   libsystem_malloc.dylib              0x24ed80ad szone_error + 364
+4   libsystem_malloc.dylib              0x24ed80c9 free_list_checksum_botch + 28
+5   libsystem_malloc.dylib              0x24ecff8b tiny_malloc_from_free_list + 994
+6   libsystem_malloc.dylib              0x24ecea0f szone_malloc_should_clear + 222
+7   libsystem_malloc.dylib              0x24ece8fb malloc_zone_malloc + 90
+8   libsystem_malloc.dylib              0x24ed1feb malloc + 46
+9   libsystem_c.dylib                   0x24df2c8b _vasprintf + 222
+10  libsystem_c.dylib                   0x24df2ba5 vasprintf_l + 32
+11  libsystem_c.dylib                   0x24df2b79 asprintf + 68
+12  libsystem_asl.dylib                 0x24ddf7c5 _asl_time_string + 852
+13  libsystem_asl.dylib                 0x24ddeddf asl_msg_to_string_raw + 210
+14  libsystem_asl.dylib                 0x24dde9a7 _asl_send_message + 882
+15  libsystem_asl.dylib                 0x24dde5d5 asl_send + 8
+16  CoreFoundation                      0x25204e37 __CFLogCString + 590
+17  CoreFoundation                      0x25204bc5 _CFLogvEx2 + 212
+18  CoreFoundation                      0x25204fb1 _CFLogvEx3 + 120
+19  Foundation                          0x25a3262f _NSLogv + 122
+20  Foundation                          0x2597903d NSLog + 28
+21  CrashLibiOS                         0x001c80b9 -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+22  CrashProbeiOS                       0x00085b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+23  UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+24  UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+25  UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+26  UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+27  UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+28  UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+29  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+30  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+31  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+32  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+33  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+34  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+35  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+36  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+37  UIKit                               0x297ff189 UIApplicationMain + 144
+38  CrashProbeiOS                       0x00084ee7 main (main.m:16)
+39  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/16/data.json
+++ b/ios/16/data.json
@@ -23,7 +23,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "wrong"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/16/data.json
+++ b/ios/16/data.json
@@ -22,7 +22,7 @@
       "arm64": "complete"
     },
     "Raygun": {
-      "armv7": "incomplete",
+      "armv7": "complete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/17/_raygun_arm64.crash
+++ b/ios/17/_raygun_arm64.crash
@@ -1,21 +1,21 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
--[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+0   libobjc.A.dylib                     0x0000000182b95dd0 cache_getImp + 16
+1   libobjc.A.dylib                     0x0000000182b8b91c lookUpImpOrForward + 284
+2   libobjc.A.dylib                     0x0000000182b95d78 _objc_msgSend_uncached_impcache + 56
+3   CrashLibiOS                         0x00000001000c0194 -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+4   CrashProbeiOS                       0x0000000100068898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+6   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+7   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+8   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+9   UIKit                               0x00000001886b8084 -[UIWindow _sendTouchesForEvent:] + 804
+10  UIKit                               0x00000001886b0c20 -[UIWindow sendEvent:] + 784
+11  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+12  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+13  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+14  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+15  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+16  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+17  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+18  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+19  CrashProbeiOS                       0x0000000100067984 main (main.m:16)
+20  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/17/_raygun_armv7.crash
+++ b/ios/17/_raygun_armv7.crash
@@ -1,25 +1,23 @@
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /usr/lib/libobjc.A.dylib | Missing class, and method</span>
--[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   libobjc.A.dylib                     0x249c3a12 cache_getImp + 18
+1   libobjc.A.dylib                     0x249bd9d1 lookUpImpOrForward + 340
+2   libobjc.A.dylib                     0x249bd873 _class_lookupMethodAndLoadCache3 + 34
+3   libobjc.A.dylib                     0x249c3cfb _objc_msgSend_uncached + 26
+4   CrashLibiOS                         0x0019b151 -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+5   CrashProbeiOS                       0x00058b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+6   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+7   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+8   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+9   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+10  UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+11  UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+12  UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+13  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+14  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+15  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+16  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+17  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+18  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+19  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+20  UIKit                               0x297ff189 UIApplicationMain + 144
+21  CrashProbeiOS                       0x00057ee7 main (main.m:16)
+22  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/17/data.json
+++ b/ios/17/data.json
@@ -22,7 +22,7 @@
       "arm64": "complete"
     },
     "Raygun": {
-      "armv7": "incomplete",
+      "armv7": "complete",
       "arm64": "incomplete"
     },
     "Bugsnag": {

--- a/ios/17/data.json
+++ b/ios/17/data.json
@@ -23,7 +23,7 @@
     },
     "Raygun": {
       "armv7": "complete",
-      "arm64": "incomplete"
+      "arm64": "complete"
     },
     "Bugsnag": {
       "armv7": "complete",

--- a/ios/18/_raygun_arm64.crash
+++ b/ios/18/_raygun_arm64.crash
@@ -1,2 +1,3 @@
-CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+<span class="cp-wrong">0   CrashLibiOS                         0x000000010008c1b4 CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:34) | Wrong line number</span>
+1   CrashLibiOS                         0x000000010008c26c CRLFramelessDWARF_test + 24
 <span class="cp-wrong">Missing frames</span>

--- a/ios/18/_raygun_armv7.crash
+++ b/ios/18/_raygun_armv7.crash
@@ -1,2 +1,3 @@
-CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+<span class="cp-wrong">0   CrashLibiOS                         0x001f6160 CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:34) | Wrong line number</span>
+1   CrashLibiOS                         0x001f61d0 CRLFramelessDWARF_test + 24
 <span class="cp-wrong">Missing frames</span>

--- a/ios/19/_raygun_arm64.crash
+++ b/ios/19/_raygun_arm64.crash
@@ -1,19 +1,20 @@
--[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+0   CrashLibiOS                         0x00000001000e4338 -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+<span class="cp-wrong">1   CrashLibiOS                         0x00000001000e431c -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:42) | Invalid frame</span>
+2   CrashProbeiOS                       0x000000010007c898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+4   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+5   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+6   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+7   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+8   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+9   UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+10  UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+11  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+12  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+13  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+14  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+15  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+16  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+17  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+18  CrashProbeiOS                       0x000000010007b984 main (main.m:16)
+19  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/19/_raygun_armv7.crash
+++ b/ios/19/_raygun_armv7.crash
@@ -1,22 +1,20 @@
--[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
--[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
-    
+0   CrashLibiOS                         0x0022f262 -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+<span class="cp-wrong">1   CrashLibiOS                         0x0022f25f -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:49) | Invalid frame</span>
+2   CrashProbeiOS                       0x000ecb59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+4   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+5   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+6   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+7   UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+8   UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+9   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+10  UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+11  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+12  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+13  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+14  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+15  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+16  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+17  UIKit                               0x297ff189 UIApplicationMain + 144
+18  CrashProbeiOS                       0x000ebee7 main (main.m:16)
+19  libdyld.dylib                       0x24dd3873 start + 2

--- a/ios/20/_raygun_arm64.crash
+++ b/ios/20/_raygun_arm64.crash
@@ -1,2 +1,3 @@
-<span class="cp-wrong">No matching image found in crash report | Missing class, method, filename, and line number</span>
+0   ???                                 0xa5a5a5a5a5a5a5a5 0x0 + 0
+1   ???                                 0xa5a5a5a5a5a5a5a5 0x0 + 0
 <span class="cp-wrong">Missing frame that shows where the crash occured</span>

--- a/ios/20/_raygun_armv7.crash
+++ b/ios/20/_raygun_armv7.crash
@@ -1,2 +1,2 @@
-<span class="cp-wrong">No matching image found in crash report | Missing class, method, filename, and line number</span>
-<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+0   ???                                 0xa5a5a5a4 0x0 + 0
+<span class="cp-wrong">1   CrashLibiOS                         0x0015e2c7 -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:55) | Wrong line number</span>

--- a/ios/20/data.json
+++ b/ios/20/data.json
@@ -21,7 +21,7 @@
       "arm64": "wrong"
     },
     "Raygun": {
-      "armv7": "wrong",
+      "armv7": "incomplete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/21/_raygun_arm64.crash
+++ b/ios/21/_raygun_arm64.crash
@@ -1,2 +1,3 @@
-<span class="cp-wrong">No matching image found in crash report | Missing class, method, filename, and line number</span>
+0   ???                                 0xa5a5a5a5a5a5a5a5 0x0 + 0
+1   ???                                 0xa5a5a5a5a5a5a5a5 0x0 + 0
 <span class="cp-wrong">Missing frame that shows where the crash occured</span>

--- a/ios/21/_raygun_armv7.crash
+++ b/ios/21/_raygun_armv7.crash
@@ -1,2 +1,2 @@
-<span class="cp-wrong">No matching image found in crash report | Missing class, method, filename, and line number</span>
-<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+0   ???                                 0xa5a5a5a4 0x0 + 0
+<span class="cp-wrong">1   CrashLibiOS                         0x001b332f -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:55) | Wrong line number</span>

--- a/ios/21/data.json
+++ b/ios/21/data.json
@@ -21,7 +21,7 @@
       "arm64": "wrong"
     },
     "Raygun": {
-      "armv7": "wrong",
+      "armv7": "incomplete",
       "arm64": "wrong"
     },
     "Bugsnag": {

--- a/ios/22/_raygun_arm64.crash
+++ b/ios/22/_raygun_arm64.crash
@@ -1,18 +1,19 @@
-<span class="cp-wrong">crash (CRLCrashSwift.swift:36) | Missing class</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x0000000100134570 @objc CRLCrashSwift.crash() (CRLCrashSwift.swift:0) | Wrong line number</span>
+1   CrashProbeiOS                       0x00000001000d4898 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x00000001886b8be8 -[UIApplication sendAction:to:from:forEvent:] + 100
+3   UIKit                               0x00000001886b8b64 -[UIControl sendAction:to:forEvent:] + 80
+4   UIKit                               0x00000001886a0870 -[UIControl _sendActionsForEvents:withEvent:] + 436
+5   UIKit                               0x00000001886b8454 -[UIControl touchesEnded:withEvent:] + 572
+6   UIKit                               0x0000000188670c0c _UIGestureRecognizerUpdate + 8988
+7   UIKit                               0x00000001886b1610 -[UIWindow _sendGesturesForEvent:] + 1132
+8   UIKit                               0x00000001886b0c0c -[UIWindow sendEvent:] + 764
+9   UIKit                               0x000000018868104c -[UIApplication sendEvent:] + 248
+10  UIKit                               0x000000018867f628 _UIApplicationHandleEventQueue + 6568
+11  CoreFoundation                      0x00000001834d509c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
+12  CoreFoundation                      0x00000001834d4b30 __CFRunLoopDoSources0 + 540
+13  CoreFoundation                      0x00000001834d2830 __CFRunLoopRun + 724
+14  CoreFoundation                      0x00000001833fcc50 CFRunLoopRunSpecific + 384
+15  GraphicsServices                    0x0000000184ce4088 GSEventRunModal + 180
+16  UIKit                               0x00000001886ea088 UIApplicationMain + 204
+17  CrashProbeiOS                       0x00000001000d3984 main (main.m:16)
+18  libdyld.dylib                       0x0000000182f9a8b8 start + 4

--- a/ios/22/_raygun_armv7.crash
+++ b/ios/22/_raygun_armv7.crash
@@ -1,19 +1,19 @@
-<span class="cp-wrong">crash (CRLCrashSwift.swift:36) | Missing class</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices | Missing class, and method</span>
-<span class="cp-wrong">No matching symbols found for /System/Library/Frameworks/UIKit.framework/UIKit | Missing class, and method</span>
-main (main.m:16)
-<span class="cp-wrong">No matching symbols found for /usr/lib/system/libdyld.dylib | Missing class, and method</span>
+<span class="cp-wrong">0   CrashLibiOS                         0x001e940c @objc CRLCrashSwift.crash() (CRLCrashSwift.swift:0) | Wrong line number</span>
+1   CrashProbeiOS                       0x000a6b59 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x297ce755 -[UIApplication sendAction:to:from:forEvent:] + 80
+3   UIKit                               0x297ce6e1 -[UIControl sendAction:to:forEvent:] + 64
+4   UIKit                               0x297b66d3 -[UIControl _sendActionsForEvents:withEvent:] + 466
+5   UIKit                               0x297ce005 -[UIControl touchesEnded:withEvent:] + 604
+6   UIKit                               0x297cdc7f -[UIWindow _sendTouchesForEvent:] + 646
+7   UIKit                               0x297c668f -[UIWindow sendEvent:] + 642
+8   UIKit                               0x29797125 -[UIApplication sendEvent:] + 204
+9   UIKit                               0x297956d3 _UIApplicationHandleEventQueue + 5010
+10  CoreFoundation                      0x251dddff __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 14
+11  CoreFoundation                      0x251dd9ed __CFRunLoopDoSources0 + 452
+12  CoreFoundation                      0x251dbd5b __CFRunLoopRun + 794
+13  CoreFoundation                      0x2512b229 CFRunLoopRunSpecific + 520
+14  CoreFoundation                      0x2512b015 CFRunLoopRunInMode + 108
+15  GraphicsServices                    0x2671bac9 GSEventRunModal + 160
+16  UIKit                               0x297ff189 UIApplicationMain + 144
+17  CrashProbeiOS                       0x000a5ee7 main (main.m:16)
+18  libdyld.dylib                       0x24dd3873 start + 2


### PR DESCRIPTION
Provider name: Raygun
Repository URL: https://github.com/MindscapeHQ/Raygun-CrashProbe

Date of testing: 09/13/2016

SDK Version:
- Raygun4iOS v2.2.1

Test environment per architecture:
- ARM64: iPhone 5s, iOS 9.3.5
- ARMv7: iPad Mini, iOS 9.3.5
