### PR TITLE
Bugsee tests from Dec 14 2016 (v1.9.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You must sign a [Contributor License Agreement](https://cla.microsoft.com/) befo
 The test case data providers per service:
 
 - Apple: [Bit Stadium GmbH](http://hockeyapp.net/)
+- Bugsee: [Bugsee, Inc](https://www.bugsee.com)
 - Bugsnag: [Bugsnag, Inc](https://bugsnag.com)
 - Crashlytics: [Bit Stadium GmbH](http://hockeyapp.net/)
 - Crittercism: [Bit Stadium GmbH](http://hockeyapp.net/)

--- a/ios/01/_bugsee_arm64.crash
+++ b/ios/01/_bugsee_arm64.crash
@@ -1,0 +1,29 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000001
+
+Thread 0 Crashed:
+0   libsystem_platform.dylib            0x0000000184830F44 _platform_memmove + 324
+1   libsystem_pthread.dylib             0x000000018483ABE0 pthread_getname_np + 164
+2   CrashLibiOS                         0x0000000100227038 -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+3   CrashProbeiOS                       0x000000010005AF10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+5   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+6   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+7   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+8   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+9   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+10  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+11  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+12  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+13  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+14  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+15  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+16  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+17  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+18  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+19  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+20  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+21  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+22  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+23  CrashProbeiOS                       0x0000000100059FF8 main (main.m:16)
+24  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/01/_bugsee_armv7.crash
+++ b/ios/01/_bugsee_armv7.crash
@@ -1,0 +1,27 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000001
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   libsystem_platform.dylib            0x235DA1A4 _platform_memmove$VARIANT$CortexA9 + 104
+1   libsystem_pthread.dylib             0x235E03C9 pthread_getname_np + 70
+2   CrashLibiOS                         0x0028B47B -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+3   CrashProbeiOS                       0x0000FC53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+5   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+6   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+7   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+8   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+9   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+10  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+11  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+12  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+13  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+14  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+15  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+16  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+17  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+18  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+19  UIKit                               0x27E8F189 UIApplicationMain + 142
+20  CrashProbeiOS                       0x0000EFDF main (main.m:16)
+21  libdyld.dylib                       0x23463873 start + 0

--- a/ios/01/data.json
+++ b/ios/01/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/02/_bugsee_arm64.crash
+++ b/ios/02/_bugsee_arm64.crash
@@ -1,0 +1,18 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x184773014
+Crashed Thread:  0
+
+Application Specific Information:
+*** Terminating app due to uncaught exception "kaboom_exception*", reason: "If this had been a real exception, you would be cursing now."
+
+Last Exception Backtrace:
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+0   libc++abi.dylib                     0x00000001841CB66C std::__terminate() (in libc++abi.dylib) + 16
+1   libc++abi.dylib                     0x00000001841CB234 __cxa_rethrow (in libc++abi.dylib) + 140
+2   libobjc.A.dylib                     0x00000001841DC71C objc_exception_rethrow + 40
+3   CoreFoundation                      0x000000018567E32C CFRunLoopRunSpecific + 556
+4   GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+5   UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+6   UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+7   CrashProbeiOS                       0x00000001000A9FF8 main (main.m:16)
+8   libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/02/_bugsee_armv7.crash
+++ b/ios/02/_bugsee_armv7.crash
@@ -1,0 +1,16 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x23536C5C
+
+Application Specific Information:
+*** Terminating app due to uncaught exception "kaboom_exception*", reason: "If this had been a real exception, you would be cursing now."
+
+Last Exception Backtrace:
+0   libc++abi.dylib                     0x23038E17 std::__terminate() (in libc++abi.dylib) + 79
+1   libc++abi.dylib                     0x230388F9 __cxa_rethrow (in libc++abi.dylib) + 98
+2   libobjc.A.dylib                     0x23046F5F objc_exception_rethrow + 40
+3   CoreFoundation                      0x237BB2AF CFRunLoopRunSpecific + 652
+4   CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+5   GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+6   UIKit                               0x27E8F189 UIApplicationMain + 142
+7   CrashProbeiOS                       0x0004BFDF main (main.m:16)
+8   libdyld.dylib                       0x23463873 start + 0

--- a/ios/02/_bugsee_armv7.crash
+++ b/ios/02/_bugsee_armv7.crash
@@ -5,6 +5,7 @@ Application Specific Information:
 *** Terminating app due to uncaught exception "kaboom_exception*", reason: "If this had been a real exception, you would be cursing now."
 
 Last Exception Backtrace:
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
 0   libc++abi.dylib                     0x23038E17 std::__terminate() (in libc++abi.dylib) + 79
 1   libc++abi.dylib                     0x230388F9 __cxa_rethrow (in libc++abi.dylib) + 98
 2   libobjc.A.dylib                     0x23046F5F objc_exception_rethrow + 40

--- a/ios/02/data.json
+++ b/ios/02/data.json
@@ -14,6 +14,10 @@
       "armv7": "wrong",
       "arm64": "wrong"
     },
+    "Bugsee": {
+      "armv7": "wrong",
+      "arm64": "wrong"
+    },
     "Apple": {
       "armv7": "wrong",
       "arm64": "wrong"

--- a/ios/03/_bugsee_arm64.crash
+++ b/ios/03/_bugsee_arm64.crash
@@ -1,0 +1,33 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x184773014
+Crashed Thread:  0
+
+Application Specific Information:
+*** Terminating app due to uncaught exception "NSGenericException", reason: "An uncaught exception! SCREAM."
+
+Last Exception Backtrace:
+0   CoreFoundation                      0x00000001857A51B8 __exceptionPreprocess + 124
+1   libobjc.A.dylib                     0x00000001841DC55C objc_exception_throw + 52
+2   CrashLibiOS                         0x00000001002BB3C0 -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                       0x00000001000DAF10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+5   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+6   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+7   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+8   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+9   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+10  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+11  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+12  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+13  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+14  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+15  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+16  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+17  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+18  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+19  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+20  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+21  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+22  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+23  CrashProbeiOS                       0x00000001000D9FF8 main (main.m:16)
+24  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/03/_bugsee_armv7.crash
+++ b/ios/03/_bugsee_armv7.crash
@@ -1,0 +1,29 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x23536C5C
+
+Application Specific Information:
+*** Terminating app due to uncaught exception "NSGenericException", reason: "An uncaught exception! SCREAM."
+
+Last Exception Backtrace:
+0   CoreFoundation                      0x238AB91B __exceptionPreprocess + 127
+1   libobjc.A.dylib                     0x23046E17 objc_exception_throw + 36
+2   CrashLibiOS                         0x0031168F -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                       0x00095C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+5   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+6   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+7   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+8   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+9   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+10  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+11  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+12  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+13  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+14  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+15  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+16  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+17  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+18  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+19  UIKit                               0x27E8F189 UIApplicationMain + 142
+20  CrashProbeiOS                       0x00094FDF main (main.m:16)
+21  libdyld.dylib                       0x23463873 start + 0

--- a/ios/03/data.json
+++ b/ios/03/data.json
@@ -14,6 +14,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "wrong",
       "arm64": "wrong"

--- a/ios/04/_bugsee_arm64.crash
+++ b/ios/04/_bugsee_arm64.crash
@@ -1,0 +1,37 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000010
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x00000001841EEF68 objc_msgSend + 8
+1   Foundation                          0x0000000186298BA4 _NS_os_log_callback + 64
+2   libsystem_trace.dylib               0x000000018485F954 _NSCF2data + 108
+3   libsystem_trace.dylib               0x000000018485F564 _os_log_encode_arg + 732
+4   libsystem_trace.dylib               0x000000018485FFB8 _os_log_encode + 1032
+5   libsystem_trace.dylib               0x0000000184863200 os_log_with_args + 888
+6   libsystem_trace.dylib               0x000000018486349C os_log_shim_with_CFString + 168
+7   CoreFoundation                      0x0000000185788DE4 _CFLogvEx3 + 148
+8   Foundation                          0x0000000186299CB0 _NSLogv + 128
+9   Foundation                          0x00000001861C0B3C NSLog + 28
+10  CrashLibiOS                         0x000000010025B444 -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+11  CrashProbeiOS                       0x0000000100076F10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+12  UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+13  UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+14  UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+15  UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+16  UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+17  UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+18  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+19  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+20  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+21  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+22  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+23  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+24  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+25  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+26  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+27  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+28  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+29  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+30  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+31  CrashProbeiOS                       0x0000000100075FF8 main (main.m:16)
+32  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/04/_bugsee_armv7.crash
+++ b/ios/04/_bugsee_armv7.crash
@@ -1,0 +1,36 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000010
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: respondsToSelector:
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x23053A62 objc_msgSend + 2
+1   Foundation                          0x240D36E9 _NSDescriptionWithStringProxyFunc + 46
+2   CoreFoundation                      0x2387D6B7 __CFStringAppendFormatCore + 6724
+3   CoreFoundation                      0x2387BC51 _CFStringCreateWithFormatAndArgumentsAux2 + 78
+4   CoreFoundation                      0x23894B51 _CFLogvEx2 + 94
+5   CoreFoundation                      0x23894FB1 _CFLogvEx3 + 118
+6   Foundation                          0x240C262F _NSLogv + 120
+7   Foundation                          0x2400903D NSLog + 26
+8   CrashLibiOS                         0x003446EB -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+9   CrashProbeiOS                       0x000C8C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+11  UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+12  UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+13  UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+14  UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+15  UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+16  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+17  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+18  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+19  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+20  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+21  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+22  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+23  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+24  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+25  UIKit                               0x27E8F189 UIApplicationMain + 142
+26  CrashProbeiOS                       0x000C7FDF main (main.m:16)
+27  libdyld.dylib                       0x23463873 start + 0

--- a/ios/04/data.json
+++ b/ios/04/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/05/_bugsee_arm64.crash
+++ b/ios/05/_bugsee_arm64.crash
@@ -1,0 +1,32 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000038
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: stringWithFormat:
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x00000001841EEF70 objc_msgSend + 16
+1   CrashLibiOS                         0x000000010022B5C8 -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                       0x000000010005AF10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+4   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+5   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+6   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+7   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+8   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+9   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+10  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+11  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+12  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+13  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+14  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+15  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+16  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+17  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+18  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+19  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+20  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+21  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+22  CrashProbeiOS                       0x0000000100059FF8 main (main.m:16)
+23  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/05/_bugsee_armv7.crash
+++ b/ios/05/_bugsee_armv7.crash
@@ -1,0 +1,29 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000036
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: stringWithFormat:
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x23053A66 objc_msgSend + 6
+1   CrashLibiOS                         0x002AB7F1 -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                       0x0002FC53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+4   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+5   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+6   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+7   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+8   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+9   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+10  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+11  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+12  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+13  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+14  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+15  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+16  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+17  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+18  UIKit                               0x27E8F189 UIApplicationMain + 142
+19  CrashProbeiOS                       0x0002EFDF main (main.m:16)
+20  libdyld.dylib                       0x23463873 start + 0

--- a/ios/05/data.json
+++ b/ios/05/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/06/_bugsee_arm64.crash
+++ b/ios/06/_bugsee_arm64.crash
@@ -1,0 +1,33 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x5FADBEB8
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: self
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x00000001841EEF70 objc_msgSend + 16
+1   CrashLibiOS                         0x0000000100253750 __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
+2   CrashLibiOS                         0x000000010025371C -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                       0x000000010007AF10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+5   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+6   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+7   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+8   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+9   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+10  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+11  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+12  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+13  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+14  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+15  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+16  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+17  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+18  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+19  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+20  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+21  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+22  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+23  CrashProbeiOS                       0x0000000100079FF8 main (main.m:16)
+24  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/06/_bugsee_armv7.crash
+++ b/ios/06/_bugsee_armv7.crash
@@ -1,0 +1,30 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0xE000000C
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: debugDescription
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x23053A66 objc_msgSend + 6
+1   CrashLibiOS                         0x002FF90F __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                         0x002FF8B3 -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                       0x00083C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+5   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+6   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+7   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+8   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+9   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+10  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+11  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+12  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+13  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+14  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+15  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+16  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+17  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+18  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+19  UIKit                               0x27E8F189 UIApplicationMain + 142
+20  CrashProbeiOS                       0x00082FDF main (main.m:16)
+21  libdyld.dylib                       0x23463873 start + 0

--- a/ios/06/data.json
+++ b/ios/06/data.json
@@ -14,6 +14,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "complete"

--- a/ios/07/_bugsee_arm64.crash
+++ b/ios/07/_bugsee_arm64.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGBUS
+Exception Codes: BUS_ADRALN at 0x1002737B0
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x0000000100273824 -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                       0x000000010001EF10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x000000010001DFF8 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/07/_bugsee_armv7.crash
+++ b/ios/07/_bugsee_armv7.crash
@@ -1,0 +1,25 @@
+Exception Type:  SIGBUS
+Exception Codes: BUS_ADRALN at 0x0036391B
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00363970 -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                       0x000E7C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x000E6FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/07/data.json
+++ b/ios/07/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "incomplete"

--- a/ios/08/_bugsee_arm64.crash
+++ b/ios/08/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGILL
+Exception Codes: ILL_ILLTRP at 0x1002B3890
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00000001002B3890 -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
+1   CrashProbeiOS                       0x00000001000CEF10 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000CDFF8 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/08/_bugsee_armv7.crash
+++ b/ios/08/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGILL
+Exception Codes: ILL_ILLTRP at 0x003759BE
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x003759BE -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
+1   CrashProbeiOS                       0x000F9C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x000F8FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/08/data.json
+++ b/ios/08/data.json
@@ -14,6 +14,10 @@
       "armv7": "complete",
       "arm64": "incomplete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "incomplete"

--- a/ios/09/_bugsee_arm64.crash
+++ b/ios/09/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGILL
+Exception Codes: ILL_ILLTRP at 0x1002C7BBC
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00000001002C7BBC -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
+1   CrashProbeiOS                       0x00000001000FF0B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000FE1A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/09/_bugsee_armv7.crash
+++ b/ios/09/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGILL
+Exception Codes: ILL_ILLTRP at 0x0037EA0A
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x0037EA0A -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
+1   CrashProbeiOS                       0x00102C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x00101FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/09/data.json
+++ b/ios/09/data.json
@@ -14,6 +14,10 @@
       "armv7": "incomplete",
       "arm64": "incomplete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "incomplete"

--- a/ios/10/_bugsee_arm64.crash
+++ b/ios/10/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000000
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00000001002E7C4C -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                       0x00000001000A30B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000A21A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/10/_bugsee_armv7.crash
+++ b/ios/10/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000000
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00358A5A -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                       0x000DCC53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x000DBFDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/10/data.json
+++ b/ios/10/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/11/_bugsee_arm64.crash
+++ b/ios/11/_bugsee_arm64.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x100DC4000
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x000000010024BD24 -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
+1   CrashProbeiOS                       0x00000001000830B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000821A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/11/_bugsee_armv7.crash
+++ b/ios/11/_bugsee_armv7.crash
@@ -1,0 +1,26 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x03133000
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00376ADE -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
+1   libsystem_kernel.dylib              0x2352341F munmap + 16
+2   CrashProbeiOS                       0x000FAC53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+4   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+5   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+6   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+7   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+8   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+9   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+10  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+11  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+12  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+13  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+14  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+15  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+16  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+17  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+18  UIKit                               0x27E8F189 UIApplicationMain + 142
+19  CrashProbeiOS                       0x000F9FDF main (main.m:16)
+20  libdyld.dylib                       0x23463873 start + 0

--- a/ios/11/data.json
+++ b/ios/11/data.json
@@ -14,6 +14,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "incomplete"

--- a/ios/12/_bugsee_arm64.crash
+++ b/ios/12/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGTRAP
+Exception Codes: #0 at 0x10028FDB8
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+<span class="cp-wrong">0   CrashLibiOS                         0x000000010028FDB8 -[CRLCrashNXPage crash] + 0 | Missing line number</span>
+1   CrashProbeiOS                       0x00000001000CF0B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000CE1A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/12/_bugsee_armv7.crash
+++ b/ios/12/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGTRAP
+Exception Codes: #0 at 0x00384B2C
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+<span class="cp-wrong">0   CrashLibiOS                         0x00384B2C -[CRLCrashNXPage crash] + 0 | Missing line number</span>
+1   CrashProbeiOS                       0x00108C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x00107FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/12/data.json
+++ b/ios/12/data.json
@@ -13,6 +13,10 @@
       "armv7": "incomplete",
       "arm64": "incomplete"
     },
+    "Bugsee": {
+      "armv7": "incomplete",
+      "arm64": "incomplete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "incomplete"

--- a/ios/13/_bugsee_arm64.crash
+++ b/ios/13/_bugsee_arm64.crash
@@ -1,0 +1,1 @@
+<span class="cp-wrong">No report</span>

--- a/ios/13/_bugsee_armv7.crash
+++ b/ios/13/_bugsee_armv7.crash
@@ -1,0 +1,1 @@
+<span class="cp-wrong">No report</span>

--- a/ios/13/data.json
+++ b/ios/13/data.json
@@ -15,6 +15,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "wrong",
+      "arm64": "wrong"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/14/_bugsee_arm64.crash
+++ b/ios/14/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGTRAP
+Exception Codes: #0 at 0x100247EEC
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x0000000100247EEC -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                       0x000000010008B0B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x000000010008A1A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/14/_bugsee_armv7.crash
+++ b/ios/14/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGTRAP
+Exception Codes: #0 at 0x002AFBE2
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x002AFBE2 -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                       0x00033C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x00032FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/14/data.json
+++ b/ios/14/data.json
@@ -13,6 +13,10 @@
       "armv7": "incomplete",
       "arm64": "incomplete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "incomplete"

--- a/ios/15/_bugsee_arm64.crash
+++ b/ios/15/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x184773014
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   libsystem_kernel.dylib              0x0000000184773014 __pthread_kill + 8
+1   libsystem_pthread.dylib             0x000000018483B450 pthread_kill + 108
+2   libsystem_c.dylib                   0x00000001846E7400 abort + 136
+3   CrashLibiOS                         0x0000000100257F80 -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                       0x00000001000870B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+6   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+7   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+8   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+9   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+10  UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+11  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+12  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+13  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+14  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+15  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+16  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+17  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+18  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+19  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+20  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+21  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+22  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+23  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+24  CrashProbeiOS                       0x00000001000861A0 main (main.m:16)
+25  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/15/_bugsee_armv7.crash
+++ b/ios/15/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x23536C5C
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   libsystem_kernel.dylib              0x23536C5C __pthread_kill + 8
+1   libsystem_pthread.dylib             0x235E0733 pthread_kill + 60
+2   libsystem_c.dylib                   0x234CB0AD abort + 106
+3   CrashLibiOS                         0x002E1C35 -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                       0x00065C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+6   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+7   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+8   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+9   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+10  UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+11  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+12  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+13  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+14  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+15  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+16  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+17  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+18  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+19  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+20  UIKit                               0x27E8F189 UIApplicationMain + 142
+21  CrashProbeiOS                       0x00064FDF main (main.m:16)
+22  libdyld.dylib                       0x23463873 start + 0

--- a/ios/15/data.json
+++ b/ios/15/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/16/_bugsee_arm64.crash
+++ b/ios/16/_bugsee_arm64.crash
@@ -1,0 +1,39 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0xABABABABABABB000
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   libsystem_notify.dylib              0x000000018482E150 _nc_table_find_64 + 28
+1   libsystem_notify.dylib              0x000000018482B308 registration_node_find + 56
+2   libsystem_notify.dylib              0x000000018482C6F8 notify_check + 116
+3   libsystem_c.dylib                   0x0000000184689E90 notify_check_tz + 32
+4   libsystem_c.dylib                   0x0000000184689D20 tzsetwall_basic + 60
+5   libsystem_c.dylib                   0x00000001846899B4 localtime_r + 44
+6   CoreFoundation                      0x000000018578A968 _populateBanner + 88
+7   CoreFoundation                      0x0000000185788C44 _CFLogvEx2Predicate + 332
+8   CoreFoundation                      0x0000000185788EE4 _CFLogvEx3 + 404
+9   Foundation                          0x0000000186299CB0 _NSLogv + 128
+10  Foundation                          0x00000001861C0B3C NSLog + 28
+11  CrashLibiOS                         0x0000000100264048 -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+12  CrashProbeiOS                       0x00000001000AB0B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+13  UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+14  UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+15  UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+16  UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+17  UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+18  UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+19  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+20  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+21  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+22  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+23  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+24  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+25  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+26  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+27  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+28  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+29  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+30  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+31  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+32  CrashProbeiOS                       0x00000001000AA1A0 main (main.m:16)
+33  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/16/_bugsee_armv7.crash
+++ b/ios/16/_bugsee_armv7.crash
@@ -1,0 +1,42 @@
+Exception Type:  SIGABRT
+Exception Codes: #0 at 0x23536C5C
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   libsystem_kernel.dylib              0x23536C5C __pthread_kill + 8
+1   libsystem_pthread.dylib             0x235E0733 pthread_kill + 60
+2   libsystem_c.dylib                   0x234CB0AD abort + 106
+3   libsystem_malloc.dylib              0x235680AD szone_error + 362
+4   libsystem_malloc.dylib              0x235680C9 free_list_checksum_botch + 26
+5   libsystem_malloc.dylib              0x2355FC73 tiny_malloc_from_free_list + 200
+6   libsystem_malloc.dylib              0x2355EA0F szone_malloc_should_clear + 220
+7   libsystem_malloc.dylib              0x2355E8FB malloc_zone_malloc + 88
+8   libsystem_malloc.dylib              0x23561FEB malloc + 44
+9   libsystem_c.dylib                   0x23482C8B _vasprintf + 220
+10  libsystem_c.dylib                   0x23482BA5 vasprintf_l + 30
+11  libsystem_c.dylib                   0x23482B79 asprintf + 66
+12  CoreFoundation                      0x23894D3B __CFLogCString + 336
+13  CoreFoundation                      0x23894BC5 _CFLogvEx2 + 210
+14  CoreFoundation                      0x23894FB1 _CFLogvEx3 + 118
+15  Foundation                          0x240C262F _NSLogv + 120
+16  Foundation                          0x2400903D NSLog + 26
+17  CrashLibiOS                         0x0037ECAB -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+18  CrashProbeiOS                       0x00102C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+19  UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+20  UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+21  UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+22  UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+23  UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+24  UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+25  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+26  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+27  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+28  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+29  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+30  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+31  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+32  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+33  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+34  UIKit                               0x27E8F189 UIApplicationMain + 142
+35  CrashProbeiOS                       0x00101FDF main (main.m:16)
+36  libdyld.dylib                       0x23463873 start + 0

--- a/ios/16/data.json
+++ b/ios/16/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/17/_bugsee_arm64.crash
+++ b/ios/17/_bugsee_arm64.crash
@@ -1,0 +1,34 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0xA5A5A5ADE5A7B000
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: description
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x00000001841EF370 cache_getImp + 16
+1   libobjc.A.dylib                     0x00000001841E4CB4 lookUpImpOrForward + 320
+2   libobjc.A.dylib                     0x00000001841EF298 _objc_msgSend_uncached + 52
+3   CrashLibiOS                         0x0000000100248138 -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+4   CrashProbeiOS                       0x00000001000770B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+6   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+7   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+8   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+9   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+10  UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+11  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+12  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+13  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+14  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+15  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+16  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+17  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+18  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+19  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+20  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+21  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+22  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+23  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+24  CrashProbeiOS                       0x00000001000761A0 main (main.m:16)
+25  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/17/_bugsee_armv7.crash
+++ b/ios/17/_bugsee_armv7.crash
@@ -1,0 +1,32 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0xA5A9A9C5
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: description
+
+Thread 0 Crashed:
+0   libobjc.A.dylib                     0x23053A12 cache_getImp + 18
+1   libobjc.A.dylib                     0x2304D9D1 lookUpImpOrForward + 338
+2   libobjc.A.dylib                     0x2304D873 _class_lookupMethodAndLoadCache3 + 32
+3   libobjc.A.dylib                     0x23053CFB _objc_msgSend_uncached + 24
+4   CrashLibiOS                         0x00370D43 -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+5   CrashProbeiOS                       0x000F4C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+6   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+7   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+8   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+9   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+10  UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+11  UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+12  UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+13  UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+14  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+15  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+16  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+17  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+18  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+19  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+20  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+21  UIKit                               0x27E8F189 UIApplicationMain + 142
+22  CrashProbeiOS                       0x000F3FDF main (main.m:16)
+23  libdyld.dylib                       0x23463873 start + 0

--- a/ios/17/data.json
+++ b/ios/17/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/18/_bugsee_arm64.crash
+++ b/ios/18/_bugsee_arm64.crash
@@ -1,0 +1,33 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000000
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x0000000100248158 CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                         0x0000000100248210 CRLFramelessDWARF_test + 20
+2   CrashLibiOS                         0x00000001002481F0 -[CRLFramelessDWARF crash] (CRLFramelessDWARF.m:49)
+3   CrashProbeiOS                       0x00000001000870B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+5   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+6   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+7   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+8   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+9   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+10  UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+11  UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+12  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+13  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+14  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+15  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+16  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+17  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+18  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+19  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+20  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+21  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+22  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+23  CrashProbeiOS                       0x00000001000861A0 main (main.m:16)
+24  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/18/_bugsee_armv7.crash
+++ b/ios/18/_bugsee_armv7.crash
@@ -1,0 +1,8 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000000
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00310D52 CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                         0x00310DC0 CRLFramelessDWARF_test + 20
+<span class="cp-wrong">Missing frames</span>

--- a/ios/18/data.json
+++ b/ios/18/data.json
@@ -14,6 +14,10 @@
       "armv7": "incomplete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "incomplete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "wrong",
       "arm64": "wrong"

--- a/ios/19/_bugsee_arm64.crash
+++ b/ios/19/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000000
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: class
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00000001003302DC -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashProbeiOS                       0x00000001000DF0B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000DE1A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/19/_bugsee_armv7.crash
+++ b/ios/19/_bugsee_armv7.crash
@@ -1,0 +1,25 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0x00000000
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x002FEE52 -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashProbeiOS                       0x00082C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x00081FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/19/data.json
+++ b/ios/19/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/20/_bugsee_arm64.crash
+++ b/ios/20/_bugsee_arm64.crash
@@ -1,0 +1,7 @@
+Exception Type:  SIGBUS
+Exception Codes: BUS_ADRALN at 0xA5A5A5A5A5A5A800
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   unknown                             0x-5A5A5A5A5A5A5C00 unknown
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>

--- a/ios/20/_bugsee_armv7.crash
+++ b/ios/20/_bugsee_armv7.crash
@@ -1,0 +1,7 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0xA5A5A5A4
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   unknown                             0x-5A5A5A5C unknown
+1   CrashLibiOS                         0x002C0EB7 -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:54)

--- a/ios/20/data.json
+++ b/ios/20/data.json
@@ -12,6 +12,10 @@
       "armv7": "complete",
       "arm64": "wrong"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "wrong"
+    },
     "Apple": {
       "armv7": "wrong",
       "arm64": "wrong"

--- a/ios/21/_bugsee_arm64.crash
+++ b/ios/21/_bugsee_arm64.crash
@@ -1,0 +1,6 @@
+Exception Type:  SIGBUS
+Exception Codes: BUS_ADRALN at 0xA5A5A5A5A5A5A800
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   unknown                             0x-5A5A5A5A5A5A5C00 unknown

--- a/ios/21/_bugsee_armv7.crash
+++ b/ios/21/_bugsee_armv7.crash
@@ -1,0 +1,7 @@
+Exception Type:  SIGSEGV
+Exception Codes: SEGV_ACCERR at 0xA5A5A5A4
+Crashed Thread:  0
+
+Thread 0 Crashed:
+0   unknown                             0x-5A5A5A5C unknown
+1   CrashLibiOS                         0x00376F1F -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:54)

--- a/ios/21/data.json
+++ b/ios/21/data.json
@@ -12,6 +12,10 @@
       "armv7": "complete",
       "arm64": "wrong"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "wrong"
+    },
     "Apple": {
       "armv7": "wrong",
       "arm64": "wrong"

--- a/ios/22/_bugsee_arm64.crash
+++ b/ios/22/_bugsee_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type:  SIGTRAP
+Exception Codes: #0 at 0x1002B8500
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00000001002B8500 @objc CRLCrashSwift.crash () -> () (CRLCrashSwift.swift:36)
+1   CrashProbeiOS                       0x00000001000FF0B8 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x000000018B68FD30 -[UIApplication sendAction:to:from:forEvent:] + 92
+3   UIKit                               0x000000018B68FCB0 -[UIControl sendAction:to:forEvent:] + 76
+4   UIKit                               0x000000018B67A128 -[UIControl _sendActionsForEvents:withEvent:] + 448
+5   UIKit                               0x000000018B68F59C -[UIControl touchesEnded:withEvent:] + 580
+6   UIKit                               0x000000018BC1A628 _UIGestureEnvironmentSortAndSendDelayedTouches + 4480
+7   UIKit                               0x000000018BC166C0 _UIGestureEnvironmentUpdate + 1160
+8   UIKit                               0x000000018BC161E0 -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:] + 404
+9   UIKit                               0x000000018BC1549C -[UIGestureEnvironment _updateGesturesForEvent:window:] + 264
+10  UIKit                               0x000000018B68A30C -[UIWindow sendEvent:] + 2956
+11  UIKit                               0x000000018B65ADA0 -[UIApplication sendEvent:] + 336
+12  UIKit                               0x000000018BE4475C __dispatchPreprocessedEventFromEventQueue + 2732
+13  UIKit                               0x000000018BE3E130 __handleEventQueue + 780
+14  CoreFoundation                      0x0000000185752B5C __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
+15  CoreFoundation                      0x00000001857524A4 __CFRunLoopDoSources0 + 520
+16  CoreFoundation                      0x00000001857500A4 __CFRunLoopRun + 800
+17  CoreFoundation                      0x000000018567E2B8 CFRunLoopRunSpecific + 440
+18  GraphicsServices                    0x0000000187132198 GSEventRunModal + 176
+19  UIKit                               0x000000018B6C57FC -[UIApplication _run] + 680
+20  UIKit                               0x000000018B6C0534 UIApplicationMain + 204
+21  CrashProbeiOS                       0x00000001000FE1A0 main (main.m:16)
+22  libdyld.dylib                       0x00000001846615B8 start + 0

--- a/ios/22/_bugsee_armv7.crash
+++ b/ios/22/_bugsee_armv7.crash
@@ -1,0 +1,28 @@
+Exception Type:  SIGTRAP
+Exception Codes: #0 at 0x00344FE8
+Crashed Thread:  0
+
+Application Specific Information:
+Selector name found in current argument registers: crash
+
+Thread 0 Crashed:
+0   CrashLibiOS                         0x00344FE8 @objc CRLCrashSwift.crash () -> () (CRLCrashSwift.swift:36)
+1   CrashProbeiOS                       0x000C8C53 -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                               0x27E5E755 -[UIApplication sendAction:to:from:forEvent:] + 78
+3   UIKit                               0x27E5E6E1 -[UIControl sendAction:to:forEvent:] + 62
+4   UIKit                               0x27E466D3 -[UIControl _sendActionsForEvents:withEvent:] + 464
+5   UIKit                               0x27E5E005 -[UIControl touchesEnded:withEvent:] + 602
+6   UIKit                               0x27E17F25 _UIGestureRecognizerUpdate + 10850
+7   UIKit                               0x27E56EC9 -[UIWindow _sendGesturesForEvent:] + 902
+8   UIKit                               0x27E5667B -[UIWindow sendEvent:] + 620
+9   UIKit                               0x27E27125 -[UIApplication sendEvent:] + 202
+10  UIKit                               0x27E256D3 _UIApplicationHandleEventQueue + 5008
+11  CoreFoundation                      0x2386DDFF __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
+12  CoreFoundation                      0x2386D9ED __CFRunLoopDoSources0 + 450
+13  CoreFoundation                      0x2386BD5B __CFRunLoopRun + 792
+14  CoreFoundation                      0x237BB229 CFRunLoopRunSpecific + 518
+15  CoreFoundation                      0x237BB015 CFRunLoopRunInMode + 106
+16  GraphicsServices                    0x24DABAC9 GSEventRunModal + 158
+17  UIKit                               0x27E8F189 UIApplicationMain + 142
+18  CrashProbeiOS                       0x000C7FDF main (main.m:16)
+19  libdyld.dylib                       0x23463873 start + 0

--- a/ios/22/data.json
+++ b/ios/22/data.json
@@ -13,6 +13,10 @@
       "armv7": "complete",
       "arm64": "complete"
     },
+    "Bugsee": {
+      "armv7": "complete",
+      "arm64": "complete"
+    },
     "Apple": {
       "armv7": "incomplete",
       "arm64": "incomplete"


### PR DESCRIPTION
Provider name: Bugsee
Repository URL: https://github.com/bugsee/CrashProbe
URL to the data: https://app.bugsee.com
Username and password for the account: crashprobe@dummy.net:crashprobe

Date of testing: 12/14/2016
SDK-Version: 1.9.10

Test environment per architecture:
iPhone 5s (ME305LLA), iOS 10.2
iPad Mini (MD531LL/A), iOS 9.3.5