### PR TITLE
Sentry tests from 04/03/2017

### DIFF
--- a/ios/01/_sentry_arm64.crash
+++ b/ios/01/_sentry_arm64.crash
@@ -1,0 +1,35 @@
+Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Exception Codes: SEGV_NOOP at 0x1
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x1.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_platform.dylib        0x30f497f44         _platform_memmove
+1   libsystem_pthread.dylib         0x30f4a8be0         pthread_getname_np
+2   libsystem_pthread.dylib         0x30f4a8be0         pthread_getname_np
+3   CrashLibiOS                     0x100033458         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+15  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31d8b3130         __handleEventQueue
+17  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+19  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+20  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+21  GraphicsServices                0x314690198         GSEventRunModal
+22  UIKit                           0x31d13a7fc         -[UIApplication _run]
+23  UIKit                           0x31d135534         UIApplicationMain
+24  CrashProbeiOS                   0x20000f2a4         main (main.m:16)
+25  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/01/_sentry_arm64.crash
+++ b/ios/01/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
 Exception Codes: SEGV_NOOP at 0x1
 Crashed Thread: 0
@@ -7,29 +10,29 @@ Attempted to dereference garbage pointer 0x1.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_platform.dylib        0x30f497f44         _platform_memmove
-1   libsystem_pthread.dylib         0x30f4a8be0         pthread_getname_np
-2   libsystem_pthread.dylib         0x30f4a8be0         pthread_getname_np
-3   CrashLibiOS                     0x100033458         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libsystem_platform.dylib        0x30f497f44         __platform_memmove
+1   libsystem_pthread.dylib         0x30f4a8be0         _pthread_getname_np
+2   libsystem_pthread.dylib         0x30f4a8be0         _pthread_getname_np
+3   CrashLibiOS                     0x1000e7458         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0x2000bc220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-15  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31d8b3130         __handleEventQueue
-17  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-19  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-20  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-21  GraphicsServices                0x314690198         GSEventRunModal
+15  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31d8b3130         ___handleEventQueue
+17  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+19  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+20  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+21  GraphicsServices                0x314690198         _GSEventRunModal
 22  UIKit                           0x31d13a7fc         -[UIApplication _run]
-23  UIKit                           0x31d135534         UIApplicationMain
-24  CrashProbeiOS                   0x20000f2a4         main (main.m:16)
-25  libdyld.dylib                   0x30f0f65b8         start
+23  UIKit                           0x31d135534         _UIApplicationMain
+24  CrashProbeiOS                   0x2000bb2a4         main (main.m:16)
+25  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/01/_sentry_arm64.crash
+++ b/ios/01/_sentry_arm64.crash
@@ -10,29 +10,29 @@ Attempted to dereference garbage pointer 0x1.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_platform.dylib        0x30f497f44         __platform_memmove
-1   libsystem_pthread.dylib         0x30f4a8be0         _pthread_getname_np
-2   libsystem_pthread.dylib         0x30f4a8be0         _pthread_getname_np
-3   CrashLibiOS                     0x1000e7458         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4   CrashProbeiOS                   0x2000bc220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-15  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31d8b3130         ___handleEventQueue
-17  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-19  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-20  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-21  GraphicsServices                0x314690198         _GSEventRunModal
-22  UIKit                           0x31d13a7fc         -[UIApplication _run]
-23  UIKit                           0x31d135534         _UIApplicationMain
-24  CrashProbeiOS                   0x2000bb2a4         main (main.m:16)
-25  libdyld.dylib                   0x30f0f65b8         _start
+0   libsystem_platform.dylib        0x30e03bf44         __platform_memmove
+1   libsystem_pthread.dylib         0x30e04cbe0         [inlined] _pthread_getname_np
+2   libsystem_pthread.dylib         0x30e04cbe0         _pthread_getname_np
+3   CrashLibiOS                     0x1000a747c         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0x20008c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+11  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+14  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+15  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31c457130         ___handleEventQueue
+17  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+19  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+20  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+21  GraphicsServices                0x313234198         _GSEventRunModal
+22  UIKit                           0x31bcde7fc         -[UIApplication _run]
+23  UIKit                           0x31bcd9534         _UIApplicationMain
+24  CrashProbeiOS                   0x20008b3cc         main (main.m:16)
+25  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/01/_sentry_armv7.crash
+++ b/ios/01/_sentry_armv7.crash
@@ -1,0 +1,35 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x1
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x1.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_platform.dylib        0x359b7752          _platform_memmove
+1   libsystem_pthread.dylib         0x359c6a31          pthread_getname_np
+2   libsystem_pthread.dylib         0x359c6a31          pthread_getname_np
+3   CrashLibiOS                     0xc247b             -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0xabe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+11  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+14  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+15  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x4114968b          __handleEventQueue
+17  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+19  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+20  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+21  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+22  GraphicsServices                0x3966fbfd          GSEventRunModal
+23  UIKit                           0x40a1a82f          -[UIApplication _run]
+24  UIKit                           0x40a14f61          UIApplicationMain
+25  CrashProbeiOS                   0xab14f             main (main.m:16)

--- a/ios/01/_sentry_armv7.crash
+++ b/ios/01/_sentry_armv7.crash
@@ -10,25 +10,25 @@ Attempted to dereference garbage pointer 0x1.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_platform.dylib        0x433271a4          __platform_memmove$VARIANT$CortexA9
-1   libsystem_pthread.dylib         0x433343c9          _pthread_getname_np
-2   libsystem_pthread.dylib         0x433343c9          _pthread_getname_np
-3   CrashLibiOS                     0x22247b            -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4   CrashProbeiOS                   0x10ee19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-10  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-11  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-12  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-13  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-14  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-16  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-17  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-18  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-19  GraphicsServices                0x462c5ac9          _GSEventRunModal
-20  UIKit                           0x4c41a189          _UIApplicationMain
-21  CrashProbeiOS                   0x10e14f            main (main.m:16)
+0   libsystem_platform.dylib        0x454df1a4          __platform_memmove$VARIANT$CortexA9
+1   libsystem_pthread.dylib         0x454ec3c9          [inlined] _pthread_getname_np
+2   libsystem_pthread.dylib         0x454ec3c9          _pthread_getname_np
+3   CrashLibiOS                     0x21d47b            -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0x109e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+10  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+11  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+12  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+13  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+14  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+16  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+17  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+18  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+19  GraphicsServices                0x4847dac9          _GSEventRunModal
+20  UIKit                           0x4e5d2189          _UIApplicationMain
+21  CrashProbeiOS                   0x10914f            main (main.m:16)

--- a/ios/01/_sentry_armv7.crash
+++ b/ios/01/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x1
 Crashed Thread: 0
@@ -7,29 +10,25 @@ Attempted to dereference garbage pointer 0x1.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_platform.dylib        0x359b7752          _platform_memmove
-1   libsystem_pthread.dylib         0x359c6a31          pthread_getname_np
-2   libsystem_pthread.dylib         0x359c6a31          pthread_getname_np
-3   CrashLibiOS                     0xc247b             -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4   CrashProbeiOS                   0xabe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-11  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-14  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-15  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x4114968b          __handleEventQueue
-17  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-19  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-20  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-21  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-22  GraphicsServices                0x3966fbfd          GSEventRunModal
-23  UIKit                           0x40a1a82f          -[UIApplication _run]
-24  UIKit                           0x40a14f61          UIApplicationMain
-25  CrashProbeiOS                   0xab14f             main (main.m:16)
+0   libsystem_platform.dylib        0x433271a4          __platform_memmove$VARIANT$CortexA9
+1   libsystem_pthread.dylib         0x433343c9          _pthread_getname_np
+2   libsystem_pthread.dylib         0x433343c9          _pthread_getname_np
+3   CrashLibiOS                     0x22247b            -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0x10ee19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+10  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+11  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+12  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+13  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+14  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+16  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+17  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+18  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+19  GraphicsServices                0x462c5ac9          _GSEventRunModal
+20  UIKit                           0x4c41a189          _UIApplicationMain
+21  CrashProbeiOS                   0x10e14f            main (main.m:16)

--- a/ios/01/data.json
+++ b/ios/01/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/02/_sentry_arm64.crash
+++ b/ios/02/_sentry_arm64.crash
@@ -1,0 +1,1 @@
+<span class="cp-wrong">No report</span>

--- a/ios/02/_sentry_armv7.crash
+++ b/ios/02/_sentry_armv7.crash
@@ -1,0 +1,1 @@
+<span class="cp-wrong">No report</span>

--- a/ios/02/data.json
+++ b/ios/02/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "wrong",
       "arm64": "wrong"
+    },
+    "Sentry": {
+      "armv7": "wrong",
+      "arm64": "wrong"
     }
   }
 }

--- a/ios/03/_sentry_arm64.crash
+++ b/ios/03/_sentry_arm64.crash
@@ -1,0 +1,33 @@
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+Application threw exception NSGenericException: An uncaught exception! SCREAM.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CoreFoundation                  0x3112521b8         __exceptionPreprocess
+1   libobjc.A.dylib                 0x30e7e855c         objc_exception_throw
+2   CrashLibiOS                     0x1000fb6b0         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0x2000c8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+10  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+13  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+14  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x31d8b3130         __handleEventQueue
+16  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+18  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+19  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+20  GraphicsServices                0x314690198         GSEventRunModal
+21  UIKit                           0x31d13a7fc         -[UIApplication _run]
+22  UIKit                           0x31d135534         UIApplicationMain
+23  CrashProbeiOS                   0x2000c72a4         main (main.m:16)
+24  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/03/_sentry_arm64.crash
+++ b/ios/03/_sentry_arm64.crash
@@ -9,28 +9,28 @@ Application threw exception NSGenericException: An uncaught exception! SCREAM.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CoreFoundation                  0x3112521b8         ___exceptionPreprocess
-1   libobjc.A.dylib                 0x30e7e855c         _objc_exception_throw
-2   CrashLibiOS                     0x10008b6b0         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
-3   CrashProbeiOS                   0x20005c220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-10  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-11  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-12  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-13  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-14  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x31d8b3130         ___handleEventQueue
-16  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-18  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-19  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-20  GraphicsServices                0x314690198         _GSEventRunModal
-21  UIKit                           0x31d13a7fc         -[UIApplication _run]
-22  UIKit                           0x31d135534         _UIApplicationMain
-23  CrashProbeiOS                   0x20005b2a4         main (main.m:16)
-24  libdyld.dylib                   0x30f0f65b8         _start
+0   CoreFoundation                  0x30fdf61b8         ___exceptionPreprocess
+1   libobjc.A.dylib                 0x30d38c55c         _objc_exception_throw
+2   CrashLibiOS                     0x1000ef6d8         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0x2000d82f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+10  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+13  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+14  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x31c457130         ___handleEventQueue
+16  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+18  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+19  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+20  GraphicsServices                0x313234198         _GSEventRunModal
+21  UIKit                           0x31bcde7fc         -[UIApplication _run]
+22  UIKit                           0x31bcd9534         _UIApplicationMain
+23  CrashProbeiOS                   0x2000d73cc         main (main.m:16)
+24  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/03/_sentry_arm64.crash
+++ b/ios/03/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_CRASH (SIGABRT)
 Crashed Thread: 0
 
@@ -6,28 +9,28 @@ Application threw exception NSGenericException: An uncaught exception! SCREAM.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CoreFoundation                  0x3112521b8         __exceptionPreprocess
-1   libobjc.A.dylib                 0x30e7e855c         objc_exception_throw
-2   CrashLibiOS                     0x1000fb6b0         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
-3   CrashProbeiOS                   0x2000c8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CoreFoundation                  0x3112521b8         ___exceptionPreprocess
+1   libobjc.A.dylib                 0x30e7e855c         _objc_exception_throw
+2   CrashLibiOS                     0x10008b6b0         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0x20005c220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 4   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 5   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 6   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 7   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 10  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 11  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 12  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 13  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-14  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x31d8b3130         __handleEventQueue
-16  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-18  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-19  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-20  GraphicsServices                0x314690198         GSEventRunModal
+14  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x31d8b3130         ___handleEventQueue
+16  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+18  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+19  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+20  GraphicsServices                0x314690198         _GSEventRunModal
 21  UIKit                           0x31d13a7fc         -[UIApplication _run]
-22  UIKit                           0x31d135534         UIApplicationMain
-23  CrashProbeiOS                   0x2000c72a4         main (main.m:16)
-24  libdyld.dylib                   0x30f0f65b8         start
+22  UIKit                           0x31d135534         _UIApplicationMain
+23  CrashProbeiOS                   0x20005b2a4         main (main.m:16)
+24  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/03/_sentry_armv7.crash
+++ b/ios/03/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_CRASH (SIGABRT)
 Crashed Thread: 0
 
@@ -6,29 +9,25 @@ Application threw exception NSGenericException: An uncaught exception! SCREAM.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CoreFoundation                  0x3680be07          __exceptionPreprocess
-1   libobjc.A.dylib                 0x34dc7077          objc_exception_throw
-2   CrashLibiOS                     0x7568f             -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
-3   CrashProbeiOS                   0x5fe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-10  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-11  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-12  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-13  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-14  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x4114968b          __handleEventQueue
-16  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-18  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-19  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-20  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-21  GraphicsServices                0x3966fbfd          GSEventRunModal
-22  UIKit                           0x40a1a82f          -[UIApplication _run]
-23  UIKit                           0x40a14f61          UIApplicationMain
-24  CrashProbeiOS                   0x5f14f             main (main.m:16)
-25  libdyld.dylib                   0x356b150b          start
+0   CoreFoundation                  0x437d591b          ___exceptionPreprocess
+1   libobjc.A.dylib                 0x427fee17          _objc_exception_throw
+2   CrashLibiOS                     0x19f68f            -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0x8be19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+9   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+11  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+12  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+13  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+15  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+16  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+17  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+18  GraphicsServices                0x462c5ac9          _GSEventRunModal
+19  UIKit                           0x4c41a189          _UIApplicationMain
+20  CrashProbeiOS                   0x8b14f             main (main.m:16)
+21  libdyld.dylib                   0x4303c873          _start

--- a/ios/03/_sentry_armv7.crash
+++ b/ios/03/_sentry_armv7.crash
@@ -9,25 +9,25 @@ Application threw exception NSGenericException: An uncaught exception! SCREAM.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CoreFoundation                  0x437d591b          ___exceptionPreprocess
-1   libobjc.A.dylib                 0x427fee17          _objc_exception_throw
-2   CrashLibiOS                     0x19f68f            -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
-3   CrashProbeiOS                   0x8be19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-9   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-10  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-11  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-12  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-13  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-14  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-15  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-16  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-17  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-18  GraphicsServices                0x462c5ac9          _GSEventRunModal
-19  UIKit                           0x4c41a189          _UIApplicationMain
-20  CrashProbeiOS                   0x8b14f             main (main.m:16)
-21  libdyld.dylib                   0x4303c873          _start
+0   CoreFoundation                  0x4598d91b          ___exceptionPreprocess
+1   libobjc.A.dylib                 0x449b6e17          _objc_exception_throw
+2   CrashLibiOS                     0x1cb68f            -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0xb7e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+9   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+11  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+12  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+13  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+15  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+16  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+17  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+18  GraphicsServices                0x4847dac9          _GSEventRunModal
+19  UIKit                           0x4e5d2189          _UIApplicationMain
+20  CrashProbeiOS                   0xb714f             main (main.m:16)
+21  libdyld.dylib                   0x451f4873          _start

--- a/ios/03/_sentry_armv7.crash
+++ b/ios/03/_sentry_armv7.crash
@@ -1,0 +1,34 @@
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+Application threw exception NSGenericException: An uncaught exception! SCREAM.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CoreFoundation                  0x3680be07          __exceptionPreprocess
+1   libobjc.A.dylib                 0x34dc7077          objc_exception_throw
+2   CrashLibiOS                     0x7568f             -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0x5fe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+10  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+13  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+14  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x4114968b          __handleEventQueue
+16  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+18  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+19  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+20  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+21  GraphicsServices                0x3966fbfd          GSEventRunModal
+22  UIKit                           0x40a1a82f          -[UIApplication _run]
+23  UIKit                           0x40a14f61          UIApplicationMain
+24  CrashProbeiOS                   0x5f14f             main (main.m:16)
+25  libdyld.dylib                   0x356b150b          start

--- a/ios/03/data.json
+++ b/ios/03/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/04/_sentry_arm64.crash
+++ b/ios/04/_sentry_arm64.crash
@@ -10,36 +10,36 @@ Attempted to dereference garbage pointer 0x10.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7faf68         _objc_msgSend
-1   Foundation                      0x31287fba4         __NS_os_log_callback
-2   libsystem_trace.dylib           0x30f4e3954         __NSCF2data
-3   libsystem_trace.dylib           0x30f4e3564         __os_log_encode_arg
-4   libsystem_trace.dylib           0x30f4e3fb8         __os_log_encode
-5   libsystem_trace.dylib           0x30f4e7200         _os_log_with_args
-6   libsystem_trace.dylib           0x30f4e749c         _os_log_shim_with_CFString
-7   CoreFoundation                  0x311235de4         __CFLogvEx3
-8   Foundation                      0x312880cb0         __NSLogv
-9   Foundation                      0x3127a7b3c         _NSLog
-10  CrashLibiOS                     0x10007f750         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
-11  CrashProbeiOS                   0x200068220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-12  UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-13  UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-14  UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-15  UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-16  UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-17  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-18  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-19  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-20  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-21  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-22  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-23  UIKit                           0x31d8b3130         ___handleEventQueue
-24  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-25  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-26  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-27  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-28  GraphicsServices                0x314690198         _GSEventRunModal
-29  UIKit                           0x31d13a7fc         -[UIApplication _run]
-30  UIKit                           0x31d135534         _UIApplicationMain
-31  CrashProbeiOS                   0x2000672a4         main (main.m:16)
-32  libdyld.dylib                   0x30f0f65b8         _start
+0   libobjc.A.dylib                 0x30d39ef68         _objc_msgSend
+1   Foundation                      0x311423ba4         __NS_os_log_callback
+2   libsystem_trace.dylib           0x30e087954         __NSCF2data
+3   libsystem_trace.dylib           0x30e087564         __os_log_encode_arg
+4   libsystem_trace.dylib           0x30e087fb8         __os_log_encode
+5   libsystem_trace.dylib           0x30e08b200         _os_log_with_args
+6   libsystem_trace.dylib           0x30e08b49c         _os_log_shim_with_CFString
+7   CoreFoundation                  0x30fdd9de4         __CFLogvEx3
+8   Foundation                      0x311424cb0         __NSLogv
+9   Foundation                      0x31134bb3c         _NSLog
+10  CrashLibiOS                     0x1000c377c         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+11  CrashProbeiOS                   0x20009c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+12  UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+13  UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+14  UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+15  UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+16  UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+17  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+18  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+19  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+20  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+21  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+22  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+23  UIKit                           0x31c457130         ___handleEventQueue
+24  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+25  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+26  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+27  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+28  GraphicsServices                0x313234198         _GSEventRunModal
+29  UIKit                           0x31bcde7fc         -[UIApplication _run]
+30  UIKit                           0x31bcd9534         _UIApplicationMain
+31  CrashProbeiOS                   0x20009b3cc         main (main.m:16)
+32  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/04/_sentry_arm64.crash
+++ b/ios/04/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x10
 Crashed Thread: 0
@@ -7,36 +10,36 @@ Attempted to dereference garbage pointer 0x10.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7faf68         objc_msgSend
-1   Foundation                      0x31287fba4         _NS_os_log_callback
-2   libsystem_trace.dylib           0x30f4e3954         _NSCF2data
-3   libsystem_trace.dylib           0x30f4e3564         _os_log_encode_arg
-4   libsystem_trace.dylib           0x30f4e3fb8         _os_log_encode
-5   libsystem_trace.dylib           0x30f4e7200         os_log_with_args
-6   libsystem_trace.dylib           0x30f4e749c         os_log_shim_with_CFString
-7   CoreFoundation                  0x311235de4         _CFLogvEx3
-8   Foundation                      0x312880cb0         _NSLogv
-9   Foundation                      0x3127a7b3c         NSLog
-10  CrashLibiOS                     0x10012f750         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
-11  CrashProbeiOS                   0x200088220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libobjc.A.dylib                 0x30e7faf68         _objc_msgSend
+1   Foundation                      0x31287fba4         __NS_os_log_callback
+2   libsystem_trace.dylib           0x30f4e3954         __NSCF2data
+3   libsystem_trace.dylib           0x30f4e3564         __os_log_encode_arg
+4   libsystem_trace.dylib           0x30f4e3fb8         __os_log_encode
+5   libsystem_trace.dylib           0x30f4e7200         _os_log_with_args
+6   libsystem_trace.dylib           0x30f4e749c         _os_log_shim_with_CFString
+7   CoreFoundation                  0x311235de4         __CFLogvEx3
+8   Foundation                      0x312880cb0         __NSLogv
+9   Foundation                      0x3127a7b3c         _NSLog
+10  CrashLibiOS                     0x10007f750         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+11  CrashProbeiOS                   0x200068220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 12  UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 13  UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 14  UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 15  UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-16  UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-17  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+16  UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+17  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 18  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 19  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 20  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 21  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-22  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-23  UIKit                           0x31d8b3130         __handleEventQueue
-24  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-25  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-26  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-27  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-28  GraphicsServices                0x314690198         GSEventRunModal
+22  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+23  UIKit                           0x31d8b3130         ___handleEventQueue
+24  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+25  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+26  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+27  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+28  GraphicsServices                0x314690198         _GSEventRunModal
 29  UIKit                           0x31d13a7fc         -[UIApplication _run]
-30  UIKit                           0x31d135534         UIApplicationMain
-31  CrashProbeiOS                   0x2000872a4         main (main.m:16)
-32  libdyld.dylib                   0x30f0f65b8         start
+30  UIKit                           0x31d135534         _UIApplicationMain
+31  CrashProbeiOS                   0x2000672a4         main (main.m:16)
+32  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/04/_sentry_arm64.crash
+++ b/ios/04/_sentry_arm64.crash
@@ -1,0 +1,42 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x10
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x10.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x30e7faf68         objc_msgSend
+1   Foundation                      0x31287fba4         _NS_os_log_callback
+2   libsystem_trace.dylib           0x30f4e3954         _NSCF2data
+3   libsystem_trace.dylib           0x30f4e3564         _os_log_encode_arg
+4   libsystem_trace.dylib           0x30f4e3fb8         _os_log_encode
+5   libsystem_trace.dylib           0x30f4e7200         os_log_with_args
+6   libsystem_trace.dylib           0x30f4e749c         os_log_shim_with_CFString
+7   CoreFoundation                  0x311235de4         _CFLogvEx3
+8   Foundation                      0x312880cb0         _NSLogv
+9   Foundation                      0x3127a7b3c         NSLog
+10  CrashLibiOS                     0x10012f750         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+11  CrashProbeiOS                   0x200088220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+12  UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+13  UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+14  UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+15  UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+16  UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+17  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+18  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+19  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+20  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+21  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+22  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+23  UIKit                           0x31d8b3130         __handleEventQueue
+24  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+25  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+26  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+27  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+28  GraphicsServices                0x314690198         GSEventRunModal
+29  UIKit                           0x31d13a7fc         -[UIApplication _run]
+30  UIKit                           0x31d135534         UIApplicationMain
+31  CrashProbeiOS                   0x2000872a4         main (main.m:16)
+32  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/04/_sentry_armv7.crash
+++ b/ios/04/_sentry_armv7.crash
@@ -1,0 +1,42 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x10
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x10.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x34dd4582          objc_msgSend
+1   Foundation                      0x37a46237          _NS_os_log_callback
+2   libsystem_trace.dylib           0x359f93d5          _NSCF2data
+3   libsystem_trace.dylib           0x359f90f5          _os_log_encode_arg
+4   libsystem_trace.dylib           0x359f98bf          _os_log_encode
+5   libsystem_trace.dylib           0x359fc563          os_log_with_args
+6   libsystem_trace.dylib           0x359fc747          os_log_shim_with_CFString
+7   CoreFoundation                  0x367f3163          _CFLogvEx3
+8   Foundation                      0x37a47073          _NSLogv
+9   Foundation                      0x3797dd75          NSLog
+10  CrashLibiOS                     0xdd6eb             -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+11  CrashProbeiOS                   0xc7e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+12  UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+13  UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+14  UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+15  UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+16  UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+17  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+18  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+19  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+20  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+21  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+22  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+23  UIKit                           0x4114968b          __handleEventQueue
+24  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+25  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+26  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+27  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+28  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+29  GraphicsServices                0x3966fbfd          GSEventRunModal
+30  UIKit                           0x40a1a82f          -[UIApplication _run]
+31  UIKit                           0x40a14f61          UIApplicationMain
+32  CrashProbeiOS                   0xc714f             main (main.m:16)

--- a/ios/04/_sentry_armv7.crash
+++ b/ios/04/_sentry_armv7.crash
@@ -10,30 +10,30 @@ Attempted to dereference garbage pointer 0x10.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x4280ba62          _objc_msgSend
-1   Foundation                      0x448446e9          __NSDescriptionWithStringProxyFunc
-2   CoreFoundation                  0x437a76b7          ___CFStringAppendFormatCore
-3   CoreFoundation                  0x437a5c51          __CFStringCreateWithFormatAndArgumentsAux2
-4   CoreFoundation                  0x437beb51          __CFLogvEx2
-5   CoreFoundation                  0x437befb1          __CFLogvEx3
-6   Foundation                      0x4483362f          __NSLogv
-7   Foundation                      0x4477a03d          _NSLog
-8   CrashLibiOS                     0x16e6eb            -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
-9   CrashProbeiOS                   0x5ae19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-10  UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-11  UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-12  UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-13  UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-14  UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-15  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-16  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-17  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-18  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-19  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-20  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-21  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-22  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-23  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-24  GraphicsServices                0x462c5ac9          _GSEventRunModal
-25  UIKit                           0x4c41a189          _UIApplicationMain
-26  CrashProbeiOS                   0x5a14f             main (main.m:16)
+0   libobjc.A.dylib                 0x449c3a62          _objc_msgSend
+1   Foundation                      0x469fc6e9          __NSDescriptionWithStringProxyFunc
+2   CoreFoundation                  0x4595f6b7          ___CFStringAppendFormatCore
+3   CoreFoundation                  0x4595dc51          __CFStringCreateWithFormatAndArgumentsAux2
+4   CoreFoundation                  0x45976b51          __CFLogvEx2
+5   CoreFoundation                  0x45976fb1          __CFLogvEx3
+6   Foundation                      0x469eb62f          __NSLogv
+7   Foundation                      0x4693203d          _NSLog
+8   CrashLibiOS                     0x2186eb            -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+9   CrashProbeiOS                   0x104e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+11  UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+12  UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+13  UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+14  UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+15  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+16  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+17  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+18  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+19  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+20  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+21  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+22  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+23  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+24  GraphicsServices                0x4847dac9          _GSEventRunModal
+25  UIKit                           0x4e5d2189          _UIApplicationMain
+26  CrashProbeiOS                   0x10414f            main (main.m:16)

--- a/ios/04/_sentry_armv7.crash
+++ b/ios/04/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x10
 Crashed Thread: 0
@@ -7,36 +10,30 @@ Attempted to dereference garbage pointer 0x10.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x34dd4582          objc_msgSend
-1   Foundation                      0x37a46237          _NS_os_log_callback
-2   libsystem_trace.dylib           0x359f93d5          _NSCF2data
-3   libsystem_trace.dylib           0x359f90f5          _os_log_encode_arg
-4   libsystem_trace.dylib           0x359f98bf          _os_log_encode
-5   libsystem_trace.dylib           0x359fc563          os_log_with_args
-6   libsystem_trace.dylib           0x359fc747          os_log_shim_with_CFString
-7   CoreFoundation                  0x367f3163          _CFLogvEx3
-8   Foundation                      0x37a47073          _NSLogv
-9   Foundation                      0x3797dd75          NSLog
-10  CrashLibiOS                     0xdd6eb             -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
-11  CrashProbeiOS                   0xc7e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-12  UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-13  UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-14  UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-15  UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-16  UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-17  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-18  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-19  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-20  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-21  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-22  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-23  UIKit                           0x4114968b          __handleEventQueue
-24  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-25  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-26  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-27  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-28  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-29  GraphicsServices                0x3966fbfd          GSEventRunModal
-30  UIKit                           0x40a1a82f          -[UIApplication _run]
-31  UIKit                           0x40a14f61          UIApplicationMain
-32  CrashProbeiOS                   0xc714f             main (main.m:16)
+0   libobjc.A.dylib                 0x4280ba62          _objc_msgSend
+1   Foundation                      0x448446e9          __NSDescriptionWithStringProxyFunc
+2   CoreFoundation                  0x437a76b7          ___CFStringAppendFormatCore
+3   CoreFoundation                  0x437a5c51          __CFStringCreateWithFormatAndArgumentsAux2
+4   CoreFoundation                  0x437beb51          __CFLogvEx2
+5   CoreFoundation                  0x437befb1          __CFLogvEx3
+6   Foundation                      0x4483362f          __NSLogv
+7   Foundation                      0x4477a03d          _NSLog
+8   CrashLibiOS                     0x16e6eb            -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+9   CrashProbeiOS                   0x5ae19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+11  UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+12  UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+13  UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+14  UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+15  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+16  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+17  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+18  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+19  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+20  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+21  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+22  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+23  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+24  GraphicsServices                0x462c5ac9          _GSEventRunModal
+25  UIKit                           0x4c41a189          _UIApplicationMain
+26  CrashProbeiOS                   0x5a14f             main (main.m:16)

--- a/ios/04/data.json
+++ b/ios/04/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/05/_sentry_arm64.crash
+++ b/ios/05/_sentry_arm64.crash
@@ -1,0 +1,33 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x38
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x38.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x30e7faf70         objc_msgSend
+1   CrashLibiOS                     0x10006b890         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x200038220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         __handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         GSEventRunModal
+20  UIKit                           0x31d13a7fc         -[UIApplication _run]
+21  UIKit                           0x31d135534         UIApplicationMain
+22  CrashProbeiOS                   0x2000372a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/05/_sentry_arm64.crash
+++ b/ios/05/_sentry_arm64.crash
@@ -10,27 +10,27 @@ Attempted to dereference garbage pointer 0x38.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7faf70         _objc_msgSend
-1   CrashLibiOS                     0x1000a7890         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
-2   CrashProbeiOS                   0x200084220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         ___handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         _GSEventRunModal
-20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         _UIApplicationMain
-22  CrashProbeiOS                   0x2000832a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         _start
+0   libobjc.A.dylib                 0x30d39ef70         _objc_msgSend
+1   CrashLibiOS                     0x1000fb8bc         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x2000582f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+9   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+12  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+13  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31c457130         ___handleEventQueue
+15  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+17  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+18  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+19  GraphicsServices                0x313234198         _GSEventRunModal
+20  UIKit                           0x31bcde7fc         -[UIApplication _run]
+21  UIKit                           0x31bcd9534         _UIApplicationMain
+22  CrashProbeiOS                   0x2000573cc         main (main.m:16)
+23  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/05/_sentry_arm64.crash
+++ b/ios/05/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x38
 Crashed Thread: 0
@@ -7,27 +10,27 @@ Attempted to dereference garbage pointer 0x38.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7faf70         objc_msgSend
-1   CrashLibiOS                     0x10006b890         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
-2   CrashProbeiOS                   0x200038220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libobjc.A.dylib                 0x30e7faf70         _objc_msgSend
+1   CrashLibiOS                     0x1000a7890         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x200084220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         __handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         GSEventRunModal
+13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         ___handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         _GSEventRunModal
 20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         UIApplicationMain
-22  CrashProbeiOS                   0x2000372a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         start
+21  UIKit                           0x31d135534         _UIApplicationMain
+22  CrashProbeiOS                   0x2000832a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/05/_sentry_armv7.crash
+++ b/ios/05/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x36
 Crashed Thread: 0
@@ -7,27 +10,23 @@ Attempted to dereference garbage pointer 0x36.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x34dd4586          objc_msgSend
-1   CrashLibiOS                     0x337f1             -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
-2   CrashProbeiOS                   0x1fe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x4114968b          __handleEventQueue
-15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-20  GraphicsServices                0x3966fbfd          GSEventRunModal
-21  UIKit                           0x40a1a82f          -[UIApplication _run]
-22  UIKit                           0x40a14f61          UIApplicationMain
-23  CrashProbeiOS                   0x1f14f             main (main.m:16)
+0   libobjc.A.dylib                 0x4280ba66          _objc_msgSend
+1   CrashLibiOS                     0x1a07f1            -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x8ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+17  GraphicsServices                0x462c5ac9          _GSEventRunModal
+18  UIKit                           0x4c41a189          _UIApplicationMain
+19  CrashProbeiOS                   0x8c14f             main (main.m:16)

--- a/ios/05/_sentry_armv7.crash
+++ b/ios/05/_sentry_armv7.crash
@@ -10,23 +10,23 @@ Attempted to dereference garbage pointer 0x36.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x4280ba66          _objc_msgSend
-1   CrashLibiOS                     0x1a07f1            -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
-2   CrashProbeiOS                   0x8ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-17  GraphicsServices                0x462c5ac9          _GSEventRunModal
-18  UIKit                           0x4c41a189          _UIApplicationMain
-19  CrashProbeiOS                   0x8c14f             main (main.m:16)
+0   libobjc.A.dylib                 0x449c3a66          _objc_msgSend
+1   CrashLibiOS                     0x1977f1            -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x83e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+10  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+11  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+15  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+17  GraphicsServices                0x4847dac9          _GSEventRunModal
+18  UIKit                           0x4e5d2189          _UIApplicationMain
+19  CrashProbeiOS                   0x8314f             main (main.m:16)

--- a/ios/05/_sentry_armv7.crash
+++ b/ios/05/_sentry_armv7.crash
@@ -1,0 +1,33 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x36
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x36.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x34dd4586          objc_msgSend
+1   CrashLibiOS                     0x337f1             -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x1fe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x4114968b          __handleEventQueue
+15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+20  GraphicsServices                0x3966fbfd          GSEventRunModal
+21  UIKit                           0x40a1a82f          -[UIApplication _run]
+22  UIKit                           0x40a14f61          UIApplicationMain
+23  CrashProbeiOS                   0x1f14f             main (main.m:16)

--- a/ios/05/data.json
+++ b/ios/05/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/06/_sentry_arm64.crash
+++ b/ios/06/_sentry_arm64.crash
@@ -2,36 +2,36 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xfdde5beb8
+Exception Codes: BUS_NOOP at 0xa87ffbeb8
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xfdde5beb8.
+Attempted to dereference garbage pointer 0xa87ffbeb8.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7faf70         _objc_msgSend
-1   CrashLibiOS                     0x1000bb9d4         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
-2   CrashLibiOS                     0x1000bb99c         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
-3   CrashProbeiOS                   0x200088220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-10  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-11  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-12  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-13  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-14  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x31d8b3130         ___handleEventQueue
-16  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-18  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-19  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-20  GraphicsServices                0x314690198         _GSEventRunModal
-21  UIKit                           0x31d13a7fc         -[UIApplication _run]
-22  UIKit                           0x31d135534         _UIApplicationMain
-23  CrashProbeiOS                   0x2000872a4         main (main.m:16)
-24  libdyld.dylib                   0x30f0f65b8         _start
+0   libobjc.A.dylib                 0x30d39ef70         _objc_msgSend
+1   CrashLibiOS                     0x10005ba00         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
+2   CrashLibiOS                     0x10005b9c8         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0x2000442f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+10  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+13  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+14  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x31c457130         ___handleEventQueue
+16  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+18  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+19  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+20  GraphicsServices                0x313234198         _GSEventRunModal
+21  UIKit                           0x31bcde7fc         -[UIApplication _run]
+22  UIKit                           0x31bcd9534         _UIApplicationMain
+23  CrashProbeiOS                   0x2000433cc         main (main.m:16)
+24  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/06/_sentry_arm64.crash
+++ b/ios/06/_sentry_arm64.crash
@@ -1,34 +1,37 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xaaf65beb8
+Exception Codes: BUS_NOOP at 0xfdde5beb8
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xaaf65beb8.
+Attempted to dereference garbage pointer 0xfdde5beb8.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7faf70         objc_msgSend
-1   CrashLibiOS                     0x1000739d4         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
-2   CrashLibiOS                     0x10007399c         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
-3   CrashProbeiOS                   0x200050220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libobjc.A.dylib                 0x30e7faf70         _objc_msgSend
+1   CrashLibiOS                     0x1000bb9d4         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
+2   CrashLibiOS                     0x1000bb99c         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0x200088220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 4   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 5   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 6   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 7   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 10  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 11  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 12  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 13  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-14  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x31d8b3130         __handleEventQueue
-16  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-18  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-19  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-20  GraphicsServices                0x314690198         GSEventRunModal
+14  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x31d8b3130         ___handleEventQueue
+16  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+18  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+19  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+20  GraphicsServices                0x314690198         _GSEventRunModal
 21  UIKit                           0x31d13a7fc         -[UIApplication _run]
-22  UIKit                           0x31d135534         UIApplicationMain
-23  CrashProbeiOS                   0x20004f2a4         main (main.m:16)
-24  libdyld.dylib                   0x30f0f65b8         start
+22  UIKit                           0x31d135534         _UIApplicationMain
+23  CrashProbeiOS                   0x2000872a4         main (main.m:16)
+24  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/06/_sentry_arm64.crash
+++ b/ios/06/_sentry_arm64.crash
@@ -1,0 +1,34 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xaaf65beb8
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xaaf65beb8.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x30e7faf70         objc_msgSend
+1   CrashLibiOS                     0x1000739d4         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
+2   CrashLibiOS                     0x10007399c         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0x200050220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+10  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+13  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+14  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x31d8b3130         __handleEventQueue
+16  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+18  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+19  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+20  GraphicsServices                0x314690198         GSEventRunModal
+21  UIKit                           0x31d13a7fc         -[UIApplication _run]
+22  UIKit                           0x31d135534         UIApplicationMain
+23  CrashProbeiOS                   0x20004f2a4         main (main.m:16)
+24  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/06/_sentry_armv7.crash
+++ b/ios/06/_sentry_armv7.crash
@@ -1,34 +1,33 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xe000000c
+Exception Codes: BUS_NOOP at 0x6000000c
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xe000000c.
+Attempted to dereference garbage pointer 0x6000000c.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x34dd4586          objc_msgSend
-1   CrashLibiOS                     0xa190f             __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
-2   CrashLibiOS                     0xa18b3             -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
-3   CrashProbeiOS                   0x8be19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-10  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-11  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-12  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-13  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-14  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x4114968b          __handleEventQueue
-16  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-18  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-19  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-20  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-21  GraphicsServices                0x3966fbfd          GSEventRunModal
-22  UIKit                           0x40a1a82f          -[UIApplication _run]
-23  UIKit                           0x40a14f61          UIApplicationMain
-24  CrashProbeiOS                   0x8b14f             main (main.m:16)
+0   libobjc.A.dylib                 0x4280ba66          _objc_msgSend
+1   CrashLibiOS                     0x22190f            __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                     0x2218b3            -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0x10de19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+9   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+11  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+12  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+13  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+15  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+16  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+17  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+18  GraphicsServices                0x462c5ac9          _GSEventRunModal
+19  UIKit                           0x4c41a189          _UIApplicationMain
+20  CrashProbeiOS                   0x10d14f            main (main.m:16)

--- a/ios/06/_sentry_armv7.crash
+++ b/ios/06/_sentry_armv7.crash
@@ -1,0 +1,34 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xe000000c
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xe000000c.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x34dd4586          objc_msgSend
+1   CrashLibiOS                     0xa190f             __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                     0xa18b3             -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0x8be19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+10  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+13  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+14  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x4114968b          __handleEventQueue
+16  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+18  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+19  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+20  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+21  GraphicsServices                0x3966fbfd          GSEventRunModal
+22  UIKit                           0x40a1a82f          -[UIApplication _run]
+23  UIKit                           0x40a14f61          UIApplicationMain
+24  CrashProbeiOS                   0x8b14f             main (main.m:16)

--- a/ios/06/_sentry_armv7.crash
+++ b/ios/06/_sentry_armv7.crash
@@ -2,32 +2,32 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x6000000c
+Exception Codes: BUS_NOOP at 0xe14fed5a
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x6000000c.
+Attempted to dereference garbage pointer 0xe14fed5a.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x4280ba66          _objc_msgSend
-1   CrashLibiOS                     0x22190f            __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
-2   CrashLibiOS                     0x2218b3            -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
-3   CrashProbeiOS                   0x10de19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-9   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-10  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-11  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-12  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-13  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-14  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-15  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-16  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-17  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-18  GraphicsServices                0x462c5ac9          _GSEventRunModal
-19  UIKit                           0x4c41a189          _UIApplicationMain
-20  CrashProbeiOS                   0x10d14f            main (main.m:16)
+0   libobjc.A.dylib                 0x449c3a66          _objc_msgSend
+1   CrashLibiOS                     0x1d490f            __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                     0x1d48b3            -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0xc0e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+9   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+11  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+12  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+13  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+15  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+16  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+17  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+18  GraphicsServices                0x4847dac9          _GSEventRunModal
+19  UIKit                           0x4e5d2189          _UIApplicationMain
+20  CrashProbeiOS                   0xc014f             main (main.m:16)

--- a/ios/06/data.json
+++ b/ios/06/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/07/_sentry_arm64.crash
+++ b/ios/07/_sentry_arm64.crash
@@ -1,32 +1,35 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x1000bfa14
+Exception Codes: BUS_NOOP at 0x100187a14
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x1000bfa14.
+Attempted to dereference garbage pointer 0x100187a14.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000bfaa4         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-1   CrashProbeiOS                   0x200094220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x100187aa4         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x2000ec220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         __handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         GSEventRunModal
+12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         ___handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         _GSEventRunModal
 19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         UIApplicationMain
-21  CrashProbeiOS                   0x2000932a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         start
+20  UIKit                           0x31d135534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000eb2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/07/_sentry_arm64.crash
+++ b/ios/07/_sentry_arm64.crash
@@ -2,34 +2,34 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x100187a14
+Exception Codes: BUS_NOOP at 0x10007fa40
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x100187a14.
+Attempted to dereference garbage pointer 0x10007fa40.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100187aa4         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-1   CrashProbeiOS                   0x2000ec220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         ___handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         _GSEventRunModal
-19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000eb2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x10007fad0         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x20005c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x20005b3cc         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/07/_sentry_arm64.crash
+++ b/ios/07/_sentry_arm64.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x1000bfa14
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x1000bfa14.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x1000bfaa4         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x200094220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         __handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         GSEventRunModal
+19  UIKit                           0x31d13a7fc         -[UIApplication _run]
+20  UIKit                           0x31d135534         UIApplicationMain
+21  CrashProbeiOS                   0x2000932a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/07/_sentry_armv7.crash
+++ b/ios/07/_sentry_armv7.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x5491b
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x5491b.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x54970             -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x3ee19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x4114968b          __handleEventQueue
+14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+19  GraphicsServices                0x3966fbfd          GSEventRunModal
+20  UIKit                           0x40a1a82f          -[UIApplication _run]
+21  UIKit                           0x40a14f61          UIApplicationMain
+22  CrashProbeiOS                   0x3e14f             main (main.m:16)

--- a/ios/07/_sentry_armv7.crash
+++ b/ios/07/_sentry_armv7.crash
@@ -2,30 +2,30 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x19091b
+Exception Codes: BUS_NOOP at 0x1a091b
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x19091b.
+Attempted to dereference garbage pointer 0x1a091b.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x190970            -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-1   CrashProbeiOS                   0x7ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-16  GraphicsServices                0x462c5ac9          _GSEventRunModal
-17  UIKit                           0x4c41a189          _UIApplicationMain
-18  CrashProbeiOS                   0x7c14f             main (main.m:16)
+0   CrashLibiOS                     0x1a0970            -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x8ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0x8c14f             main (main.m:16)

--- a/ios/07/_sentry_armv7.crash
+++ b/ios/07/_sentry_armv7.crash
@@ -1,32 +1,31 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x5491b
+Exception Codes: BUS_NOOP at 0x19091b
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x5491b.
+Attempted to dereference garbage pointer 0x19091b.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x54970             -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-1   CrashProbeiOS                   0x3ee19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x4114968b          __handleEventQueue
-14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-19  GraphicsServices                0x3966fbfd          GSEventRunModal
-20  UIKit                           0x40a1a82f          -[UIApplication _run]
-21  UIKit                           0x40a14f61          UIApplicationMain
-22  CrashProbeiOS                   0x3e14f             main (main.m:16)
+0   CrashLibiOS                     0x190970            -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x7ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+16  GraphicsServices                0x462c5ac9          _GSEventRunModal
+17  UIKit                           0x4c41a189          _UIApplicationMain
+18  CrashProbeiOS                   0x7c14f             main (main.m:16)

--- a/ios/07/data.json
+++ b/ios/07/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/08/_sentry_arm64.crash
+++ b/ios/08/_sentry_arm64.crash
@@ -1,5 +1,8 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x100057b30
+Exception Codes: ILL_NOOP at 0x100097b30
 Crashed Thread: 0
 
 Application Specific Information:
@@ -7,26 +10,26 @@ Exception 2, Code 3574368159, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100057b30         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
-1   CrashProbeiOS                   0x20003c220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x100097b30         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
+1   CrashProbeiOS                   0x200068220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         __handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         GSEventRunModal
+12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         ___handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         _GSEventRunModal
 19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         UIApplicationMain
-21  CrashProbeiOS                   0x20003b2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         start
+20  UIKit                           0x31d135534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000672a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/08/_sentry_arm64.crash
+++ b/ios/08/_sentry_arm64.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0x100057b30
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 3574368159, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x100057b30         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
+1   CrashProbeiOS                   0x20003c220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         __handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         GSEventRunModal
+19  UIKit                           0x31d13a7fc         -[UIApplication _run]
+20  UIKit                           0x31d135534         UIApplicationMain
+21  CrashProbeiOS                   0x20003b2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/08/_sentry_arm64.crash
+++ b/ios/08/_sentry_arm64.crash
@@ -2,7 +2,7 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x100097b30
+Exception Codes: ILL_NOOP at 0x100063b5c
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,26 +10,26 @@ Exception 2, Code 3574368159, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100097b30         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
-1   CrashProbeiOS                   0x200068220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         ___handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         _GSEventRunModal
-19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000672a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x100063b5c         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
+1   CrashProbeiOS                   0x20004c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x20004b3cc         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/08/_sentry_armv7.crash
+++ b/ios/08/_sentry_armv7.crash
@@ -1,5 +1,8 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x1169be
+Exception Codes: ILL_NOOP at 0x1ef9be
 Crashed Thread: 0
 
 Application Specific Information:
@@ -7,26 +10,22 @@ Exception 2, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1169be            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
-1   CrashProbeiOS                   0x101e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x4114968b          __handleEventQueue
-14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-19  GraphicsServices                0x3966fbfd          GSEventRunModal
-20  UIKit                           0x40a1a82f          -[UIApplication _run]
-21  UIKit                           0x40a14f61          UIApplicationMain
-22  CrashProbeiOS                   0x10114f            main (main.m:16)
+0   CrashLibiOS                     0x1ef9be            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
+1   CrashProbeiOS                   0xdbe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+16  GraphicsServices                0x462c5ac9          _GSEventRunModal
+17  UIKit                           0x4c41a189          _UIApplicationMain
+18  CrashProbeiOS                   0xdb14f             main (main.m:16)

--- a/ios/08/_sentry_armv7.crash
+++ b/ios/08/_sentry_armv7.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0x1169be
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 1, Subcode 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x1169be            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
+1   CrashProbeiOS                   0x101e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x4114968b          __handleEventQueue
+14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+19  GraphicsServices                0x3966fbfd          GSEventRunModal
+20  UIKit                           0x40a1a82f          -[UIApplication _run]
+21  UIKit                           0x40a14f61          UIApplicationMain
+22  CrashProbeiOS                   0x10114f            main (main.m:16)

--- a/ios/08/_sentry_armv7.crash
+++ b/ios/08/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x1ef9be
+Exception Codes: ILL_NOOP at 0x20d9be
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,22 +10,22 @@ Exception 2, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1ef9be            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
-1   CrashProbeiOS                   0xdbe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-16  GraphicsServices                0x462c5ac9          _GSEventRunModal
-17  UIKit                           0x4c41a189          _UIApplicationMain
-18  CrashProbeiOS                   0xdb14f             main (main.m:16)
+0   CrashLibiOS                     0x20d9be            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
+1   CrashProbeiOS                   0xf9e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0xf914f             main (main.m:16)

--- a/ios/08/data.json
+++ b/ios/08/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "incomplete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/09/_sentry_arm64.crash
+++ b/ios/09/_sentry_arm64.crash
@@ -2,7 +2,7 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x1000cbbbc
+Exception Codes: ILL_NOOP at 0x1000b7be8
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,26 +10,26 @@ Exception 2, Code 4160266240, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000cbbbc         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
-1   CrashProbeiOS                   0x2000a4220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         ___handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         _GSEventRunModal
-19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000a32a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x1000b7be8         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
+1   CrashProbeiOS                   0x2000842f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000833cc         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/09/_sentry_arm64.crash
+++ b/ios/09/_sentry_arm64.crash
@@ -1,5 +1,8 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x10008bbbc
+Exception Codes: ILL_NOOP at 0x1000cbbbc
 Crashed Thread: 0
 
 Application Specific Information:
@@ -7,26 +10,26 @@ Exception 2, Code 4160266240, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10008bbbc         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
-1   CrashProbeiOS                   0x200070220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x1000cbbbc         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
+1   CrashProbeiOS                   0x2000a4220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         __handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         GSEventRunModal
+12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         ___handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         _GSEventRunModal
 19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         UIApplicationMain
-21  CrashProbeiOS                   0x20006f2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         start
+20  UIKit                           0x31d135534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000a32a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/09/_sentry_arm64.crash
+++ b/ios/09/_sentry_arm64.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0x10008bbbc
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 4160266240, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x10008bbbc         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
+1   CrashProbeiOS                   0x200070220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         __handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         GSEventRunModal
+19  UIKit                           0x31d13a7fc         -[UIApplication _run]
+20  UIKit                           0x31d135534         UIApplicationMain
+21  CrashProbeiOS                   0x20006f2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/09/_sentry_armv7.crash
+++ b/ios/09/_sentry_armv7.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0xa7a0a
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 1, Subcode 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0xa7a0a             -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
+1   CrashProbeiOS                   0x92e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x4114968b          __handleEventQueue
+14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+19  GraphicsServices                0x3966fbfd          GSEventRunModal
+20  UIKit                           0x40a1a82f          -[UIApplication _run]
+21  UIKit                           0x40a14f61          UIApplicationMain
+22  CrashProbeiOS                   0x9214f             main (main.m:16)

--- a/ios/09/_sentry_armv7.crash
+++ b/ios/09/_sentry_armv7.crash
@@ -1,5 +1,8 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0xa7a0a
+Exception Codes: ILL_NOOP at 0x16da0a
 Crashed Thread: 0
 
 Application Specific Information:
@@ -7,26 +10,22 @@ Exception 2, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0xa7a0a             -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
-1   CrashProbeiOS                   0x92e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x4114968b          __handleEventQueue
-14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-19  GraphicsServices                0x3966fbfd          GSEventRunModal
-20  UIKit                           0x40a1a82f          -[UIApplication _run]
-21  UIKit                           0x40a14f61          UIApplicationMain
-22  CrashProbeiOS                   0x9214f             main (main.m:16)
+0   CrashLibiOS                     0x16da0a            -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
+1   CrashProbeiOS                   0x59e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+16  GraphicsServices                0x462c5ac9          _GSEventRunModal
+17  UIKit                           0x4c41a189          _UIApplicationMain
+18  CrashProbeiOS                   0x5914f             main (main.m:16)

--- a/ios/09/_sentry_armv7.crash
+++ b/ios/09/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x16da0a
+Exception Codes: ILL_NOOP at 0x212a0a
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,22 +10,22 @@ Exception 2, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x16da0a            -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
-1   CrashProbeiOS                   0x59e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-16  GraphicsServices                0x462c5ac9          _GSEventRunModal
-17  UIKit                           0x4c41a189          _UIApplicationMain
-18  CrashProbeiOS                   0x5914f             main (main.m:16)
+0   CrashLibiOS                     0x212a0a            -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
+1   CrashProbeiOS                   0xfee19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0xfe14f             main (main.m:16)

--- a/ios/09/data.json
+++ b/ios/09/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "incomplete",
       "arm64": "incomplete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/10/_sentry_arm64.crash
+++ b/ios/10/_sentry_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x1000a3c4c         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x200088220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         __handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         GSEventRunModal
+19  UIKit                           0x31d13a7fc         -[UIApplication _run]
+20  UIKit                           0x31d135534         UIApplicationMain
+21  CrashProbeiOS                   0x2000872a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/10/_sentry_arm64.crash
+++ b/ios/10/_sentry_arm64.crash
@@ -9,26 +9,26 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100077c4c         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-1   CrashProbeiOS                   0x200050220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         ___handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         _GSEventRunModal
-19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         _UIApplicationMain
-21  CrashProbeiOS                   0x20004f2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x100053c78         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x2000242f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000233cc         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/10/_sentry_arm64.crash
+++ b/ios/10/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Crashed Thread: 0
 
@@ -6,26 +9,26 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000a3c4c         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-1   CrashProbeiOS                   0x200088220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x100077c4c         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x200050220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         __handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         GSEventRunModal
+12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         ___handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         _GSEventRunModal
 19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         UIApplicationMain
-21  CrashProbeiOS                   0x2000872a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         start
+20  UIKit                           0x31d135534         _UIApplicationMain
+21  CrashProbeiOS                   0x20004f2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/10/_sentry_armv7.crash
+++ b/ios/10/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
 Crashed Thread: 0
 
@@ -6,26 +9,22 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x200a5a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-1   CrashProbeiOS                   0x72e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x4114968b          __handleEventQueue
-14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-19  GraphicsServices                0x3966fbfd          GSEventRunModal
-20  UIKit                           0x40a1a82f          -[UIApplication _run]
-21  UIKit                           0x40a14f61          UIApplicationMain
-22  CrashProbeiOS                   0x7214f             main (main.m:16)
+0   CrashLibiOS                     0x156a5a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x42e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+16  GraphicsServices                0x462c5ac9          _GSEventRunModal
+17  UIKit                           0x4c41a189          _UIApplicationMain
+18  CrashProbeiOS                   0x4214f             main (main.m:16)

--- a/ios/10/_sentry_armv7.crash
+++ b/ios/10/_sentry_armv7.crash
@@ -1,0 +1,31 @@
+Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x200a5a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x72e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x4114968b          __handleEventQueue
+14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+19  GraphicsServices                0x3966fbfd          GSEventRunModal
+20  UIKit                           0x40a1a82f          -[UIApplication _run]
+21  UIKit                           0x40a14f61          UIApplicationMain
+22  CrashProbeiOS                   0x7214f             main (main.m:16)

--- a/ios/10/_sentry_armv7.crash
+++ b/ios/10/_sentry_armv7.crash
@@ -9,22 +9,22 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x156a5a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-1   CrashProbeiOS                   0x42e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-16  GraphicsServices                0x462c5ac9          _GSEventRunModal
-17  UIKit                           0x4c41a189          _UIApplicationMain
-18  CrashProbeiOS                   0x4214f             main (main.m:16)
+0   CrashLibiOS                     0x132a5a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x1ee19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0x1e14f             main (main.m:16)

--- a/ios/10/data.json
+++ b/ios/10/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/11/_sentry_arm64.crash
+++ b/ios/11/_sentry_arm64.crash
@@ -2,35 +2,34 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x10469c000
+Exception Codes: BUS_NOOP at 0x104650000
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x10469c000.
+Attempted to dereference garbage pointer 0x104650000.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000cfd24         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
-1   CrashLibiOS                     0x1000cfd20         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:41)
-2   CrashProbeiOS                   0x2000b8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         ___handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         _GSEventRunModal
-20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         _UIApplicationMain
-22  CrashProbeiOS                   0x2000b72a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x1000afd50         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
+1   CrashProbeiOS                   0x2000802f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x20007f3cc         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/11/_sentry_arm64.crash
+++ b/ios/11/_sentry_arm64.crash
@@ -1,0 +1,33 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x1029f8000
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x1029f8000.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x100057d24         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
+1   CrashLibiOS                     0x100057d20         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:41)
+2   CrashProbeiOS                   0x200034220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         __handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         GSEventRunModal
+20  UIKit                           0x31d13a7fc         -[UIApplication _run]
+21  UIKit                           0x31d135534         UIApplicationMain
+22  CrashProbeiOS                   0x2000332a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/11/_sentry_arm64.crash
+++ b/ios/11/_sentry_arm64.crash
@@ -1,33 +1,36 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x1029f8000
+Exception Codes: BUS_NOOP at 0x10469c000
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x1029f8000.
+Attempted to dereference garbage pointer 0x10469c000.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100057d24         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
-1   CrashLibiOS                     0x100057d20         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:41)
-2   CrashProbeiOS                   0x200034220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x1000cfd24         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
+1   CrashLibiOS                     0x1000cfd20         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:41)
+2   CrashProbeiOS                   0x2000b8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         __handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         GSEventRunModal
+13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         ___handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         _GSEventRunModal
 20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         UIApplicationMain
-22  CrashProbeiOS                   0x2000332a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         start
+21  UIKit                           0x31d135534         _UIApplicationMain
+22  CrashProbeiOS                   0x2000b72a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/11/_sentry_armv7.crash
+++ b/ios/11/_sentry_armv7.crash
@@ -1,0 +1,33 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xcf8000
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xcf8000.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0xb1ade             -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
+1   libsystem_kernel.dylib          0x3583436f          munmap
+2   CrashProbeiOS                   0x9ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x4114968b          __handleEventQueue
+15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+20  GraphicsServices                0x3966fbfd          GSEventRunModal
+21  UIKit                           0x40a1a82f          -[UIApplication _run]
+22  UIKit                           0x40a14f61          UIApplicationMain
+23  CrashProbeiOS                   0x9c14f             main (main.m:16)

--- a/ios/11/_sentry_armv7.crash
+++ b/ios/11/_sentry_armv7.crash
@@ -2,31 +2,31 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x26a0000
+Exception Codes: BUS_NOOP at 0x3425000
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x26a0000.
+Attempted to dereference garbage pointer 0x3425000.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1e4ade            -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
-1   libsystem_kernel.dylib          0x431bd41f          _munmap
-2   CrashProbeiOS                   0xd0e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-17  GraphicsServices                0x462c5ac9          _GSEventRunModal
-18  UIKit                           0x4c41a189          _UIApplicationMain
-19  CrashProbeiOS                   0xd014f             main (main.m:16)
+0   CrashLibiOS                     0x1e8ade            -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
+1   libsystem_kernel.dylib          0x4537541f          _munmap
+2   CrashProbeiOS                   0xd4e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+10  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+11  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+15  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+17  GraphicsServices                0x4847dac9          _GSEventRunModal
+18  UIKit                           0x4e5d2189          _UIApplicationMain
+19  CrashProbeiOS                   0xd414f             main (main.m:16)

--- a/ios/11/_sentry_armv7.crash
+++ b/ios/11/_sentry_armv7.crash
@@ -1,33 +1,32 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xcf8000
+Exception Codes: BUS_NOOP at 0x26a0000
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xcf8000.
+Attempted to dereference garbage pointer 0x26a0000.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0xb1ade             -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
-1   libsystem_kernel.dylib          0x3583436f          munmap
-2   CrashProbeiOS                   0x9ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x4114968b          __handleEventQueue
-15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-20  GraphicsServices                0x3966fbfd          GSEventRunModal
-21  UIKit                           0x40a1a82f          -[UIApplication _run]
-22  UIKit                           0x40a14f61          UIApplicationMain
-23  CrashProbeiOS                   0x9c14f             main (main.m:16)
+0   CrashLibiOS                     0x1e4ade            -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
+1   libsystem_kernel.dylib          0x431bd41f          _munmap
+2   CrashProbeiOS                   0xd0e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+17  GraphicsServices                0x462c5ac9          _GSEventRunModal
+18  UIKit                           0x4c41a189          _UIApplicationMain
+19  CrashProbeiOS                   0xd014f             main (main.m:16)

--- a/ios/11/data.json
+++ b/ios/11/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/12/_sentry_arm64.crash
+++ b/ios/12/_sentry_arm64.crash
@@ -5,30 +5,30 @@ Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 1408440, Subcode 8
+Exception 6, Code 359864, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x100157db8         -[CRLCrashNXPage crash] | Missing line number</span>
-1   CrashProbeiOS                   0x2000b0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         ___handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         _GSEventRunModal
-19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000af2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         _start
+<span class="cp-wrong">0   CrashLibiOS                     0x100057db8         -[CRLCrashNXPage crash] | Missing line number</span>
+1   CrashProbeiOS                   0x200038220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000372a4         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/12/_sentry_arm64.crash
+++ b/ios/12/_sentry_arm64.crash
@@ -1,31 +1,34 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 343480, Subcode 8
+Exception 6, Code 1408440, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x100053db8         -[CRLCrashNXPage crash] | Missing line number</span>
-1   CrashProbeiOS                   0x200038220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+<span class="cp-wrong">0   CrashLibiOS                     0x100157db8         -[CRLCrashNXPage crash] | Missing line number</span>
+1   CrashProbeiOS                   0x2000b0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         __handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         GSEventRunModal
+12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         ___handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         _GSEventRunModal
 19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         UIApplicationMain
-21  CrashProbeiOS                   0x2000372a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         start
+20  UIKit                           0x31d135534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000af2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/12/_sentry_arm64.crash
+++ b/ios/12/_sentry_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type: EXC_BREAKPOINT
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 6, Code 343480, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+<span class="cp-wrong">0   CrashLibiOS                     0x100053db8         -[CRLCrashNXPage crash] | Missing line number</span>
+1   CrashProbeiOS                   0x200038220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         __handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         GSEventRunModal
+19  UIKit                           0x31d13a7fc         -[UIApplication _run]
+20  UIKit                           0x31d135534         UIApplicationMain
+21  CrashProbeiOS                   0x2000372a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/12/_sentry_armv7.crash
+++ b/ios/12/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
@@ -6,26 +9,22 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x9fb2c             -[CRLCrashNXPage crash] | Missing line number</span>
-1   CrashProbeiOS                   0x8be19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x4114968b          __handleEventQueue
-14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-19  GraphicsServices                0x3966fbfd          GSEventRunModal
-20  UIKit                           0x40a1a82f          -[UIApplication _run]
-21  UIKit                           0x40a14f61          UIApplicationMain
-22  CrashProbeiOS                   0x8b14f             main (main.m:16)
+<span class="cp-wrong">0   CrashLibiOS                     0x13bb2c            -[CRLCrashNXPage crash] | Missing line number</span>
+1   CrashProbeiOS                   0x27e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+16  GraphicsServices                0x462c5ac9          _GSEventRunModal
+17  UIKit                           0x4c41a189          _UIApplicationMain
+18  CrashProbeiOS                   0x2714f             main (main.m:16)

--- a/ios/12/_sentry_armv7.crash
+++ b/ios/12/_sentry_armv7.crash
@@ -9,22 +9,22 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x13bb2c            -[CRLCrashNXPage crash] | Missing line number</span>
-1   CrashProbeiOS                   0x27e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-16  GraphicsServices                0x462c5ac9          _GSEventRunModal
-17  UIKit                           0x4c41a189          _UIApplicationMain
-18  CrashProbeiOS                   0x2714f             main (main.m:16)
+<span class="cp-wrong">0   CrashLibiOS                     0x1b0b2c            -[CRLCrashNXPage crash] | Missing line number</span>
+1   CrashProbeiOS                   0x9ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0x9c14f             main (main.m:16)

--- a/ios/12/_sentry_armv7.crash
+++ b/ios/12/_sentry_armv7.crash
@@ -1,0 +1,31 @@
+Exception Type: EXC_BREAKPOINT
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 6, Code 1, Subcode 0
+
+Thread 0 name:
+Thread 0 Crashed:
+<span class="cp-wrong">0   CrashLibiOS                     0x9fb2c             -[CRLCrashNXPage crash] | Missing line number</span>
+1   CrashProbeiOS                   0x8be19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x4114968b          __handleEventQueue
+14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+19  GraphicsServices                0x3966fbfd          GSEventRunModal
+20  UIKit                           0x40a1a82f          -[UIApplication _run]
+21  UIKit                           0x40a14f61          UIApplicationMain
+22  CrashProbeiOS                   0x8b14f             main (main.m:16)

--- a/ios/12/data.json
+++ b/ios/12/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "incomplete",
       "arm64": "incomplete"
+    },
+    "Sentry": {
+      "armv7": "incomplete",
+      "arm64": "incomplete"
     }
   }
 }

--- a/ios/13/_sentry_arm64.crash
+++ b/ios/13/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x16fc8fff0
 Crashed Thread: 0

--- a/ios/13/_sentry_arm64.crash
+++ b/ios/13/_sentry_arm64.crash
@@ -2,7 +2,7 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x16fc8fff0
+Exception Codes: BUS_NOOP at 0x16fc57ff0
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,8 +10,8 @@ Stack overflow in (null)
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100093e40         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
-1   CrashLibiOS                     0x100093e54         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
-2   CrashLibiOS                     0x100093e54         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+0   CrashLibiOS                     0x1000cbe6c         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
+1   CrashLibiOS                     0x1000cbe80         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLibiOS                     0x1000cbe80         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
 ...
-99  CrashLibiOS                     0x100093e54         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+99  CrashLibiOS                     0x1000cbe80         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/ios/13/_sentry_arm64.crash
+++ b/ios/13/_sentry_arm64.crash
@@ -1,0 +1,14 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x16fc8fff0
+Crashed Thread: 0
+
+Application Specific Information:
+Stack overflow in (null)
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x100093e40         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
+1   CrashLibiOS                     0x100093e54         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLibiOS                     0x100093e54         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+...
+99  CrashLibiOS                     0x100093e54         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/ios/13/_sentry_armv7.crash
+++ b/ios/13/_sentry_armv7.crash
@@ -1,0 +1,14 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x1eeffc
+Crashed Thread: 0
+
+Application Specific Information:
+Stack overflow in (null)
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x10fb76            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
+1   CrashLibiOS                     0x10fb8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLibiOS                     0x10fb8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+...
+99  CrashLibiOS                     0x10fb8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/ios/13/_sentry_armv7.crash
+++ b/ios/13/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0x1eeffc
 Crashed Thread: 0

--- a/ios/13/_sentry_armv7.crash
+++ b/ios/13/_sentry_armv7.crash
@@ -10,8 +10,8 @@ Stack overflow in (null)
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10fb76            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
-1   CrashLibiOS                     0x10fb8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
-2   CrashLibiOS                     0x10fb8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+0   CrashLibiOS                     0x1c4b76            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
+1   CrashLibiOS                     0x1c4b8b            [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLibiOS                     0x1c4b8b            [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
 ...
-99  CrashLibiOS                     0x10fb8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+99  CrashLibiOS                     0x1c4b8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/ios/13/data.json
+++ b/ios/13/data.json
@@ -34,6 +34,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/14/_sentry_arm64.crash
+++ b/ios/14/_sentry_arm64.crash
@@ -1,0 +1,31 @@
+Exception Type: EXC_BREAKPOINT
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 6, Code 589548, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x10008feec         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x200070220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         __handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         GSEventRunModal
+19  UIKit                           0x31d13a7fc         -[UIApplication _run]
+20  UIKit                           0x31d135534         UIApplicationMain
+21  CrashProbeiOS                   0x20006f2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/14/_sentry_arm64.crash
+++ b/ios/14/_sentry_arm64.crash
@@ -5,30 +5,30 @@ Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 1457900, Subcode 8
+Exception 6, Code 1048344, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100163eec         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
-1   CrashProbeiOS                   0x2000bc220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         ___handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         _GSEventRunModal
-19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000bb2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x1000fff18         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x2000cc2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000cb3cc         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/14/_sentry_arm64.crash
+++ b/ios/14/_sentry_arm64.crash
@@ -1,31 +1,34 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 589548, Subcode 8
+Exception 6, Code 1457900, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10008feec         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
-1   CrashProbeiOS                   0x200070220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x100163eec         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x2000bc220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 2   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 3   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 4   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 5   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+6   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 8   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 9   UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 10  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 11  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-12  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31d8b3130         __handleEventQueue
-14  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-16  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-17  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-18  GraphicsServices                0x314690198         GSEventRunModal
+12  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31d8b3130         ___handleEventQueue
+14  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+17  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x314690198         _GSEventRunModal
 19  UIKit                           0x31d13a7fc         -[UIApplication _run]
-20  UIKit                           0x31d135534         UIApplicationMain
-21  CrashProbeiOS                   0x20006f2a4         main (main.m:16)
-22  libdyld.dylib                   0x30f0f65b8         start
+20  UIKit                           0x31d135534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000bb2a4         main (main.m:16)
+22  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/14/_sentry_armv7.crash
+++ b/ios/14/_sentry_armv7.crash
@@ -1,0 +1,31 @@
+Exception Type: EXC_BREAKPOINT
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 6, Code 1, Subcode 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0xc2be2             -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0xace19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x4114968b          __handleEventQueue
+14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+19  GraphicsServices                0x3966fbfd          GSEventRunModal
+20  UIKit                           0x40a1a82f          -[UIApplication _run]
+21  UIKit                           0x40a14f61          UIApplicationMain
+22  CrashProbeiOS                   0xac14f             main (main.m:16)

--- a/ios/14/_sentry_armv7.crash
+++ b/ios/14/_sentry_armv7.crash
@@ -9,22 +9,22 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x16cbe2            -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
-1   CrashProbeiOS                   0x58e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-16  GraphicsServices                0x462c5ac9          _GSEventRunModal
-17  UIKit                           0x4c41a189          _UIApplicationMain
-18  CrashProbeiOS                   0x5814f             main (main.m:16)
+0   CrashLibiOS                     0x141be2            -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x2de19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0x2d14f             main (main.m:16)

--- a/ios/14/_sentry_armv7.crash
+++ b/ios/14/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
@@ -6,26 +9,22 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0xc2be2             -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
-1   CrashProbeiOS                   0xace19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-8   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-11  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-12  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x4114968b          __handleEventQueue
-14  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-16  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-17  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-18  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-19  GraphicsServices                0x3966fbfd          GSEventRunModal
-20  UIKit                           0x40a1a82f          -[UIApplication _run]
-21  UIKit                           0x40a14f61          UIApplicationMain
-22  CrashProbeiOS                   0xac14f             main (main.m:16)
+0   CrashLibiOS                     0x16cbe2            -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x58e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+9   UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+10  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+14  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+16  GraphicsServices                0x462c5ac9          _GSEventRunModal
+17  UIKit                           0x4c41a189          _UIApplicationMain
+18  CrashProbeiOS                   0x5814f             main (main.m:16)

--- a/ios/14/data.json
+++ b/ios/14/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "incomplete",
       "arm64": "incomplete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/15/_sentry_arm64.crash
+++ b/ios/15/_sentry_arm64.crash
@@ -9,29 +9,29 @@ Signal 6, Code 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x30f2ff014         ___pthread_kill
-1   libsystem_pthread.dylib         0x30f4a9450         _pthread_kill
-2   libsystem_c.dylib               0x30f1a3400         _abort
-3   CrashLibiOS                     0x100057f80         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
-4   CrashProbeiOS                   0x200040220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-15  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31d8b3130         ___handleEventQueue
-17  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-19  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-20  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-21  GraphicsServices                0x314690198         _GSEventRunModal
-22  UIKit                           0x31d13a7fc         -[UIApplication _run]
-23  UIKit                           0x31d135534         _UIApplicationMain
-24  CrashProbeiOS                   0x20003f2a4         main (main.m:16)
-25  libdyld.dylib                   0x30f0f65b8         _start
+0   libsystem_kernel.dylib          0x30dea3014         ___pthread_kill
+1   libsystem_pthread.dylib         0x30e04d450         _pthread_kill
+2   libsystem_c.dylib               0x30dd47400         _abort
+3   CrashLibiOS                     0x10006bfac         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x2000502f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+11  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+14  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+15  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31c457130         ___handleEventQueue
+17  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+19  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+20  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+21  GraphicsServices                0x313234198         _GSEventRunModal
+22  UIKit                           0x31bcde7fc         -[UIApplication _run]
+23  UIKit                           0x31bcd9534         _UIApplicationMain
+24  CrashProbeiOS                   0x20004f3cc         main (main.m:16)
+25  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/15/_sentry_arm64.crash
+++ b/ios/15/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_CRASH (SIGABRT)
 Crashed Thread: 0
 
@@ -6,29 +9,29 @@ Signal 6, Code 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x30f2ff014         __pthread_kill
-1   libsystem_pthread.dylib         0x30f4a9450         pthread_kill
-2   libsystem_c.dylib               0x30f1a3400         abort
-3   CrashLibiOS                     0x1000d7f80         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
-4   CrashProbeiOS                   0x2000c0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libsystem_kernel.dylib          0x30f2ff014         ___pthread_kill
+1   libsystem_pthread.dylib         0x30f4a9450         _pthread_kill
+2   libsystem_c.dylib               0x30f1a3400         _abort
+3   CrashLibiOS                     0x100057f80         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x200040220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-15  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31d8b3130         __handleEventQueue
-17  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-19  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-20  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-21  GraphicsServices                0x314690198         GSEventRunModal
+15  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31d8b3130         ___handleEventQueue
+17  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+19  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+20  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+21  GraphicsServices                0x314690198         _GSEventRunModal
 22  UIKit                           0x31d13a7fc         -[UIApplication _run]
-23  UIKit                           0x31d135534         UIApplicationMain
-24  CrashProbeiOS                   0x2000bf2a4         main (main.m:16)
-25  libdyld.dylib                   0x30f0f65b8         start
+23  UIKit                           0x31d135534         _UIApplicationMain
+24  CrashProbeiOS                   0x20003f2a4         main (main.m:16)
+25  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/15/_sentry_arm64.crash
+++ b/ios/15/_sentry_arm64.crash
@@ -1,0 +1,34 @@
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+Signal 6, Code 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_kernel.dylib          0x30f2ff014         __pthread_kill
+1   libsystem_pthread.dylib         0x30f4a9450         pthread_kill
+2   libsystem_c.dylib               0x30f1a3400         abort
+3   CrashLibiOS                     0x1000d7f80         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x2000c0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+15  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31d8b3130         __handleEventQueue
+17  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+19  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+20  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+21  GraphicsServices                0x314690198         GSEventRunModal
+22  UIKit                           0x31d13a7fc         -[UIApplication _run]
+23  UIKit                           0x31d135534         UIApplicationMain
+24  CrashProbeiOS                   0x2000bf2a4         main (main.m:16)
+25  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/15/_sentry_armv7.crash
+++ b/ios/15/_sentry_armv7.crash
@@ -9,25 +9,25 @@ Signal 6, Code 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x431d0c5c          ___pthread_kill
-1   libsystem_pthread.dylib         0x43334733          _pthread_kill
-2   libsystem_c.dylib               0x430c30ad          _abort
-3   CrashLibiOS                     0x178c35            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
-4   CrashProbeiOS                   0x64e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-10  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-11  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-12  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-13  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-14  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-16  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-17  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-18  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-19  GraphicsServices                0x462c5ac9          _GSEventRunModal
-20  UIKit                           0x4c41a189          _UIApplicationMain
-21  CrashProbeiOS                   0x6414f             main (main.m:16)
+0   libsystem_kernel.dylib          0x45388c5c          ___pthread_kill
+1   libsystem_pthread.dylib         0x454ec733          _pthread_kill
+2   libsystem_c.dylib               0x4527b0ad          _abort
+3   CrashLibiOS                     0x1d3c35            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0xbfe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+10  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+11  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+12  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+13  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+14  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+16  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+17  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+18  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+19  GraphicsServices                0x4847dac9          _GSEventRunModal
+20  UIKit                           0x4e5d2189          _UIApplicationMain
+21  CrashProbeiOS                   0xbf14f             main (main.m:16)

--- a/ios/15/_sentry_armv7.crash
+++ b/ios/15/_sentry_armv7.crash
@@ -1,0 +1,34 @@
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+Signal 6, Code 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_kernel.dylib          0x35848ad4          __pthread_kill
+1   libsystem_pthread.dylib         0x359c717b          pthread_kill
+2   libsystem_c.dylib               0x3573b309          abort
+3   CrashLibiOS                     0x1f9c35            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x79e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+11  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+14  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+15  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x4114968b          __handleEventQueue
+17  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+19  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+20  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+21  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+22  GraphicsServices                0x3966fbfd          GSEventRunModal
+23  UIKit                           0x40a1a82f          -[UIApplication _run]
+24  UIKit                           0x40a14f61          UIApplicationMain
+25  CrashProbeiOS                   0x7914f             main (main.m:16)

--- a/ios/15/_sentry_armv7.crash
+++ b/ios/15/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_CRASH (SIGABRT)
 Crashed Thread: 0
 
@@ -6,29 +9,25 @@ Signal 6, Code 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x35848ad4          __pthread_kill
-1   libsystem_pthread.dylib         0x359c717b          pthread_kill
-2   libsystem_c.dylib               0x3573b309          abort
-3   CrashLibiOS                     0x1f9c35            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
-4   CrashProbeiOS                   0x79e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-11  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-14  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-15  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x4114968b          __handleEventQueue
-17  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-19  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-20  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-21  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-22  GraphicsServices                0x3966fbfd          GSEventRunModal
-23  UIKit                           0x40a1a82f          -[UIApplication _run]
-24  UIKit                           0x40a14f61          UIApplicationMain
-25  CrashProbeiOS                   0x7914f             main (main.m:16)
+0   libsystem_kernel.dylib          0x431d0c5c          ___pthread_kill
+1   libsystem_pthread.dylib         0x43334733          _pthread_kill
+2   libsystem_c.dylib               0x430c30ad          _abort
+3   CrashLibiOS                     0x178c35            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x64e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+10  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+11  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+12  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+13  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+14  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+16  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+17  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+18  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+19  GraphicsServices                0x462c5ac9          _GSEventRunModal
+20  UIKit                           0x4c41a189          _UIApplicationMain
+21  CrashProbeiOS                   0x6414f             main (main.m:16)

--- a/ios/15/data.json
+++ b/ios/15/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/16/_sentry_arm64.crash
+++ b/ios/16/_sentry_arm64.crash
@@ -1,0 +1,43 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xabababababababab
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xabababababababab.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_notify.dylib          0x30f48a15c         _nc_table_find_64
+1   libsystem_notify.dylib          0x30f487308         registration_node_find
+2   libsystem_notify.dylib          0x30f4886f8         notify_check
+3   libsystem_c.dylib               0x30f145e90         notify_check_tz
+4   libsystem_c.dylib               0x30f145d20         tzsetwall_basic
+5   libsystem_c.dylib               0x30f1459b4         localtime_r
+6   CoreFoundation                  0x311237968         _populateBanner
+7   CoreFoundation                  0x311235c44         _CFLogvEx2Predicate
+8   CoreFoundation                  0x311235ee4         _CFLogvEx3
+9   Foundation                      0x312880cb0         _NSLogv
+10  Foundation                      0x3127a7b3c         NSLog
+11  CrashLibiOS                     0x1000cc048         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+12  CrashProbeiOS                   0x2000a8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+13  UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+14  UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+15  UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+16  UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+17  UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+18  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+19  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+20  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+21  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+22  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+23  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+24  UIKit                           0x31d8b3130         __handleEventQueue
+25  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+26  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+27  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+28  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+29  GraphicsServices                0x314690198         GSEventRunModal
+30  UIKit                           0x31d13a7fc         -[UIApplication _run]
+31  UIKit                           0x31d135534         UIApplicationMain
+32  CrashProbeiOS                   0x2000a72a4         main (main.m:16)
+33  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/16/_sentry_arm64.crash
+++ b/ios/16/_sentry_arm64.crash
@@ -2,45 +2,42 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xababababababac7b
+Exception Codes: BUS_NOOP at 0xabababababababab
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xababababababac7b.
+Attempted to dereference garbage pointer 0xabababababababab.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_notify.dylib          0x30f48a150         __nc_table_find_64
-1   libsystem_notify.dylib          0x30f487308         _registration_node_find
-2   libsystem_notify.dylib          0x30f4886f8         _notify_check
-3   libsystem_c.dylib               0x30f145e90         _notify_check_tz
-4   libsystem_c.dylib               0x30f145d20         _tzsetwall_basic
-5   libsystem_c.dylib               0x30f1459b4         _localtime_r
-6   CoreFoundation                  0x311237968         __populateBanner
-7   CoreFoundation                  0x311235c44         __CFLogvEx2Predicate
-8   CoreFoundation                  0x311235ee4         __CFLogvEx3
-9   Foundation                      0x312880cb0         __NSLogv
-10  Foundation                      0x3127a7b3c         _NSLog
-11  CrashLibiOS                     0x1000ec048         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
-12  CrashProbeiOS                   0x2000d0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-13  UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-14  UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-15  UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-16  UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-17  UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-18  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-19  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-20  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-21  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-22  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-23  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-24  UIKit                           0x31d8b3130         ___handleEventQueue
-25  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-26  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-27  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-28  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-29  GraphicsServices                0x314690198         _GSEventRunModal
-30  UIKit                           0x31d13a7fc         -[UIApplication _run]
-31  UIKit                           0x31d135534         _UIApplicationMain
-32  CrashProbeiOS                   0x2000cf2a4         main (main.m:16)
-33  libdyld.dylib                   0x30f0f65b8         _start
+0   libobjc.A.dylib                 0x30d38a698         _object_setClass
+1   CoreFoundation                  0x30fcc9540         [inlined] __CFRuntimeCreateInstance
+2   CoreFoundation                  0x30fcc9540         __CFRuntimeCreateInstance
+3   CoreFoundation                  0x30fdb5234         __CFStringCreateWithFormatAndArgumentsAux2
+4   CoreFoundation                  0x30fdd9b90         __CFLogvEx2Predicate
+5   CoreFoundation                  0x30fdd9ee4         __CFLogvEx3
+6   Foundation                      0x311424cb0         __NSLogv
+7   Foundation                      0x31134bb3c         _NSLog
+8   CrashLibiOS                     0x1000f4048         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+9   CrashProbeiOS                   0x2000c4220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+11  UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+12  UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+13  UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+14  UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+15  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+16  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+17  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+18  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+19  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+20  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+21  UIKit                           0x31c457130         ___handleEventQueue
+22  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+23  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+24  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+25  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+26  GraphicsServices                0x313234198         _GSEventRunModal
+27  UIKit                           0x31bcde7fc         -[UIApplication _run]
+28  UIKit                           0x31bcd9534         _UIApplicationMain
+29  CrashProbeiOS                   0x2000c32a4         main (main.m:16)
+30  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/16/_sentry_arm64.crash
+++ b/ios/16/_sentry_arm64.crash
@@ -1,43 +1,46 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xabababababababab
+Exception Codes: BUS_NOOP at 0xababababababac7b
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xabababababababab.
+Attempted to dereference garbage pointer 0xababababababac7b.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_notify.dylib          0x30f48a15c         _nc_table_find_64
-1   libsystem_notify.dylib          0x30f487308         registration_node_find
-2   libsystem_notify.dylib          0x30f4886f8         notify_check
-3   libsystem_c.dylib               0x30f145e90         notify_check_tz
-4   libsystem_c.dylib               0x30f145d20         tzsetwall_basic
-5   libsystem_c.dylib               0x30f1459b4         localtime_r
-6   CoreFoundation                  0x311237968         _populateBanner
-7   CoreFoundation                  0x311235c44         _CFLogvEx2Predicate
-8   CoreFoundation                  0x311235ee4         _CFLogvEx3
-9   Foundation                      0x312880cb0         _NSLogv
-10  Foundation                      0x3127a7b3c         NSLog
-11  CrashLibiOS                     0x1000cc048         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
-12  CrashProbeiOS                   0x2000a8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libsystem_notify.dylib          0x30f48a150         __nc_table_find_64
+1   libsystem_notify.dylib          0x30f487308         _registration_node_find
+2   libsystem_notify.dylib          0x30f4886f8         _notify_check
+3   libsystem_c.dylib               0x30f145e90         _notify_check_tz
+4   libsystem_c.dylib               0x30f145d20         _tzsetwall_basic
+5   libsystem_c.dylib               0x30f1459b4         _localtime_r
+6   CoreFoundation                  0x311237968         __populateBanner
+7   CoreFoundation                  0x311235c44         __CFLogvEx2Predicate
+8   CoreFoundation                  0x311235ee4         __CFLogvEx3
+9   Foundation                      0x312880cb0         __NSLogv
+10  Foundation                      0x3127a7b3c         _NSLog
+11  CrashLibiOS                     0x1000ec048         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+12  CrashProbeiOS                   0x2000d0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 13  UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 14  UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 15  UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 16  UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-17  UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-18  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+17  UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+18  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 19  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 20  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 21  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 22  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-23  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-24  UIKit                           0x31d8b3130         __handleEventQueue
-25  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-26  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-27  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-28  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-29  GraphicsServices                0x314690198         GSEventRunModal
+23  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+24  UIKit                           0x31d8b3130         ___handleEventQueue
+25  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+26  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+27  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+28  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+29  GraphicsServices                0x314690198         _GSEventRunModal
 30  UIKit                           0x31d13a7fc         -[UIApplication _run]
-31  UIKit                           0x31d135534         UIApplicationMain
-32  CrashProbeiOS                   0x2000a72a4         main (main.m:16)
-33  libdyld.dylib                   0x30f0f65b8         start
+31  UIKit                           0x31d135534         _UIApplicationMain
+32  CrashProbeiOS                   0x2000cf2a4         main (main.m:16)
+33  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/16/_sentry_armv7.crash
+++ b/ios/16/_sentry_armv7.crash
@@ -1,40 +1,40 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x5b1a7c08
+Exception Codes: BUS_NOOP at 0xabababab
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x5b1a7c08.
+Attempted to dereference garbage pointer 0xabababab.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_malloc.dylib          0x358cf842          szone_size
-1   libsystem_malloc.dylib          0x358cf47d          free
-2   CoreFoundation                  0x367d8e21          __CFStringAppendFormatCore
-3   CoreFoundation                  0x367d5c13          _CFStringCreateWithFormatAndArgumentsAux2
-4   CoreFoundation                  0x367f2fa1          _CFLogvEx2Predicate
-5   CoreFoundation                  0x367f323d          _CFLogvEx3
-6   Foundation                      0x37a47073          _NSLogv
-7   Foundation                      0x3797dd75          NSLog
-8   CrashLibiOS                     0x101cab            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
-9   CrashProbeiOS                   0xece19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-10  UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-11  UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-12  UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-13  UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-14  UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-15  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-16  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-17  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-18  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-19  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-20  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-21  UIKit                           0x4114968b          __handleEventQueue
-22  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-23  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-24  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-25  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-26  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-27  GraphicsServices                0x3966fbfd          GSEventRunModal
-28  UIKit                           0x40a1a82f          -[UIApplication _run]
-29  UIKit                           0x40a14f61          UIApplicationMain
-30  CrashProbeiOS                   0xec14f             main (main.m:16)
+0   libobjc.A.dylib                 0x427fdbac          _object_setClass
+1   CoreFoundation                  0x436df2fd          __CFRuntimeCreateInstance
+2   CoreFoundation                  0x436df2fd          __CFRuntimeCreateInstance
+3   CoreFoundation                  0x436f3aa5          _CFStringCreateMutable
+4   CoreFoundation                  0x437a5c29          __CFStringCreateWithFormatAndArgumentsAux2
+5   CoreFoundation                  0x437beb51          __CFLogvEx2
+6   CoreFoundation                  0x437befb1          __CFLogvEx3
+7   Foundation                      0x4483362f          __NSLogv
+8   Foundation                      0x4477a03d          _NSLog
+9   CrashLibiOS                     0x186cab            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+10  CrashProbeiOS                   0x72e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+11  UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+12  UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+13  UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+14  UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+15  UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+16  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+17  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+18  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+19  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+20  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+21  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+22  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+23  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+24  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+25  GraphicsServices                0x462c5ac9          _GSEventRunModal
+26  UIKit                           0x4c41a189          _UIApplicationMain
+27  CrashProbeiOS                   0x7214f             main (main.m:16)

--- a/ios/16/_sentry_armv7.crash
+++ b/ios/16/_sentry_armv7.crash
@@ -1,40 +1,45 @@
 OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
-Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xabababab
+Exception Type: EXC_CRASH (SIGABRT)
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xabababab.
+Rogue memory write has corrupted memory.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x427fdbac          _object_setClass
-1   CoreFoundation                  0x436df2fd          __CFRuntimeCreateInstance
-2   CoreFoundation                  0x436df2fd          __CFRuntimeCreateInstance
-3   CoreFoundation                  0x436f3aa5          _CFStringCreateMutable
-4   CoreFoundation                  0x437a5c29          __CFStringCreateWithFormatAndArgumentsAux2
-5   CoreFoundation                  0x437beb51          __CFLogvEx2
-6   CoreFoundation                  0x437befb1          __CFLogvEx3
-7   Foundation                      0x4483362f          __NSLogv
-8   Foundation                      0x4477a03d          _NSLog
-9   CrashLibiOS                     0x186cab            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
-10  CrashProbeiOS                   0x72e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-11  UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-12  UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-13  UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-14  UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-15  UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-16  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-17  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-18  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-19  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-20  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-21  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-22  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-23  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-24  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-25  GraphicsServices                0x462c5ac9          _GSEventRunModal
-26  UIKit                           0x4c41a189          _UIApplicationMain
-27  CrashProbeiOS                   0x7214f             main (main.m:16)
+0   libsystem_kernel.dylib          0x45388c5c          ___pthread_kill
+1   libsystem_pthread.dylib         0x454ec733          _pthread_kill
+2   libsystem_c.dylib               0x4527b0ad          _abort
+3   libsystem_malloc.dylib          0x453f60ad          _szone_error
+4   libsystem_malloc.dylib          0x453f60c9          _free_list_checksum_botch
+5   libsystem_malloc.dylib          0x453edf8b          _tiny_malloc_from_free_list
+6   libsystem_malloc.dylib          0x453eca0f          _szone_malloc_should_clear
+7   libsystem_malloc.dylib          0x453eff5f          _malloc_zone_calloc
+8   libsystem_malloc.dylib          0x453efeef          _calloc
+9   CoreFoundation                  0x4595f1bf          ___CFStringAppendFormatCore
+10  CoreFoundation                  0x4595dc51          __CFStringCreateWithFormatAndArgumentsAux2
+11  CoreFoundation                  0x45976b51          __CFLogvEx2
+12  CoreFoundation                  0x45976fb1          __CFLogvEx3
+13  Foundation                      0x469eb62f          __NSLogv
+14  Foundation                      0x4693203d          _NSLog
+15  CrashLibiOS                     0x15bcab            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+16  CrashProbeiOS                   0x47e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+17  UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+18  UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+19  UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+20  UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+21  UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+22  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+23  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+24  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+25  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+26  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+27  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+28  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+29  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+30  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+31  GraphicsServices                0x4847dac9          _GSEventRunModal
+32  UIKit                           0x4e5d2189          _UIApplicationMain
+33  CrashProbeiOS                   0x4714f             main (main.m:16)

--- a/ios/16/_sentry_armv7.crash
+++ b/ios/16/_sentry_armv7.crash
@@ -1,0 +1,40 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x5b1a7c08
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x5b1a7c08.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_malloc.dylib          0x358cf842          szone_size
+1   libsystem_malloc.dylib          0x358cf47d          free
+2   CoreFoundation                  0x367d8e21          __CFStringAppendFormatCore
+3   CoreFoundation                  0x367d5c13          _CFStringCreateWithFormatAndArgumentsAux2
+4   CoreFoundation                  0x367f2fa1          _CFLogvEx2Predicate
+5   CoreFoundation                  0x367f323d          _CFLogvEx3
+6   Foundation                      0x37a47073          _NSLogv
+7   Foundation                      0x3797dd75          NSLog
+8   CrashLibiOS                     0x101cab            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+9   CrashProbeiOS                   0xece19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+11  UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+12  UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+13  UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+14  UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+15  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+16  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+17  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+18  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+19  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+20  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+21  UIKit                           0x4114968b          __handleEventQueue
+22  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+23  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+24  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+25  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+26  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+27  GraphicsServices                0x3966fbfd          GSEventRunModal
+28  UIKit                           0x40a1a82f          -[UIApplication _run]
+29  UIKit                           0x40a14f61          UIApplicationMain
+30  CrashProbeiOS                   0xec14f             main (main.m:16)

--- a/ios/16/data.json
+++ b/ios/16/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/17/_sentry_arm64.crash
+++ b/ios/17/_sentry_arm64.crash
@@ -2,37 +2,37 @@ OS Version: iOS 10.2.1 (14D27)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a5ade7edaff5
+Exception Codes: BUS_NOOP at 0xa5a5a5adf7adaff5
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xa5a5a5ade7edaff5.
+Attempted to dereference garbage pointer 0xa5a5a5adf7adaff5.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7fb370         _cache_getImp
-1   libobjc.A.dylib                 0x30e7f0cb4         _lookUpImpOrForward
-2   libobjc.A.dylib                 0x30e7fb298         __objc_msgSend_uncached
-3   CrashLibiOS                     0x100020138         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
-4   CrashProbeiOS                   0x200008220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-15  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31d8b3130         ___handleEventQueue
-17  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-19  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-20  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-21  GraphicsServices                0x314690198         _GSEventRunModal
-22  UIKit                           0x31d13a7fc         -[UIApplication _run]
-23  UIKit                           0x31d135534         _UIApplicationMain
-24  CrashProbeiOS                   0x2000072a4         main (main.m:16)
-25  libdyld.dylib                   0x30f0f65b8         _start
+0   libobjc.A.dylib                 0x30d39f370         _cache_getImp
+1   libobjc.A.dylib                 0x30d394cb4         _lookUpImpOrForward
+2   libobjc.A.dylib                 0x30d39f298         __objc_msgSend_uncached
+3   CrashLibiOS                     0x100040138         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+4   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+11  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+14  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+15  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31c457130         ___handleEventQueue
+17  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+19  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+20  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+21  GraphicsServices                0x313234198         _GSEventRunModal
+22  UIKit                           0x31bcde7fc         -[UIApplication _run]
+23  UIKit                           0x31bcd9534         _UIApplicationMain
+24  CrashProbeiOS                   0x20000f2a4         main (main.m:16)
+25  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/17/_sentry_arm64.crash
+++ b/ios/17/_sentry_arm64.crash
@@ -1,0 +1,35 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xa5a5a5ade7edaff5
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xa5a5a5ade7edaff5.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x30e7fb370         cache_getImp
+1   libobjc.A.dylib                 0x30e7f0cb4         lookUpImpOrForward
+2   libobjc.A.dylib                 0x30e7fb298         _objc_msgSend_uncached
+3   CrashLibiOS                     0x100060138         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+4   CrashProbeiOS                   0x20002c220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+15  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31d8b3130         __handleEventQueue
+17  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+19  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+20  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+21  GraphicsServices                0x314690198         GSEventRunModal
+22  UIKit                           0x31d13a7fc         -[UIApplication _run]
+23  UIKit                           0x31d135534         UIApplicationMain
+24  CrashProbeiOS                   0x20002b2a4         main (main.m:16)
+25  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/17/_sentry_arm64.crash
+++ b/ios/17/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0xa5a5a5ade7edaff5
 Crashed Thread: 0
@@ -7,29 +10,29 @@ Attempted to dereference garbage pointer 0xa5a5a5ade7edaff5.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30e7fb370         cache_getImp
-1   libobjc.A.dylib                 0x30e7f0cb4         lookUpImpOrForward
-2   libobjc.A.dylib                 0x30e7fb298         _objc_msgSend_uncached
-3   CrashLibiOS                     0x100060138         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
-4   CrashProbeiOS                   0x20002c220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   libobjc.A.dylib                 0x30e7fb370         _cache_getImp
+1   libobjc.A.dylib                 0x30e7f0cb4         _lookUpImpOrForward
+2   libobjc.A.dylib                 0x30e7fb298         __objc_msgSend_uncached
+3   CrashLibiOS                     0x100020138         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+4   CrashProbeiOS                   0x200008220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 5   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 6   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 7   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 8   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 11  UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 12  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 13  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 14  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-15  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31d8b3130         __handleEventQueue
-17  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-19  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-20  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-21  GraphicsServices                0x314690198         GSEventRunModal
+15  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x31d8b3130         ___handleEventQueue
+17  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+19  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+20  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+21  GraphicsServices                0x314690198         _GSEventRunModal
 22  UIKit                           0x31d13a7fc         -[UIApplication _run]
-23  UIKit                           0x31d135534         UIApplicationMain
-24  CrashProbeiOS                   0x20002b2a4         main (main.m:16)
-25  libdyld.dylib                   0x30f0f65b8         start
+23  UIKit                           0x31d135534         _UIApplicationMain
+24  CrashProbeiOS                   0x2000072a4         main (main.m:16)
+25  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/17/_sentry_armv7.crash
+++ b/ios/17/_sentry_armv7.crash
@@ -1,36 +1,35 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a6b1cd
+Exception Codes: BUS_NOOP at 0xa5a9a9c5
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xa5a6b1cd.
+Attempted to dereference garbage pointer 0xa5a9a9c5.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x34dd4552          cache_getImp
-1   libobjc.A.dylib                 0x34dce7b3          lookUpImpOrForward
-2   libobjc.A.dylib                 0x34dce661          _class_lookupMethodAndLoadCache3
-3   libobjc.A.dylib                 0x34dd496f          _objc_msgSend_uncached
-4   CrashLibiOS                     0x121d43            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
-5   CrashProbeiOS                   0x10be19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-6   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-7   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-8   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-9   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-10  UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-11  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-12  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-13  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-14  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-15  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-16  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-17  UIKit                           0x4114968b          __handleEventQueue
-18  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-19  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-20  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-21  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-22  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-23  GraphicsServices                0x3966fbfd          GSEventRunModal
-24  UIKit                           0x40a1a82f          -[UIApplication _run]
-25  UIKit                           0x40a14f61          UIApplicationMain
-26  CrashProbeiOS                   0x10b14f            main (main.m:16)
+0   libobjc.A.dylib                 0x4280ba12          _cache_getImp
+1   libobjc.A.dylib                 0x428059d1          _lookUpImpOrForward
+2   libobjc.A.dylib                 0x42805873          _class_lookupMethodAndLoadCache3
+3   libobjc.A.dylib                 0x4280bcfb          _objc_msgSend_uncached
+4   CrashLibiOS                     0x16bd43            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+5   CrashProbeiOS                   0x57e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+6   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+7   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+8   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+9   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+10  UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+11  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+12  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+13  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+14  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+15  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+17  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+18  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+19  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+20  GraphicsServices                0x462c5ac9          _GSEventRunModal
+21  UIKit                           0x4c41a189          _UIApplicationMain
+22  CrashProbeiOS                   0x5714f             main (main.m:16)

--- a/ios/17/_sentry_armv7.crash
+++ b/ios/17/_sentry_armv7.crash
@@ -1,0 +1,36 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xa5a6b1cd
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xa5a6b1cd.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0x34dd4552          cache_getImp
+1   libobjc.A.dylib                 0x34dce7b3          lookUpImpOrForward
+2   libobjc.A.dylib                 0x34dce661          _class_lookupMethodAndLoadCache3
+3   libobjc.A.dylib                 0x34dd496f          _objc_msgSend_uncached
+4   CrashLibiOS                     0x121d43            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+5   CrashProbeiOS                   0x10be19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+6   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+7   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+8   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+9   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+10  UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+11  UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+12  UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+13  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+14  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+15  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+16  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+17  UIKit                           0x4114968b          __handleEventQueue
+18  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+19  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+20  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+21  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+22  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+23  GraphicsServices                0x3966fbfd          GSEventRunModal
+24  UIKit                           0x40a1a82f          -[UIApplication _run]
+25  UIKit                           0x40a14f61          UIApplicationMain
+26  CrashProbeiOS                   0x10b14f            main (main.m:16)

--- a/ios/17/_sentry_armv7.crash
+++ b/ios/17/_sentry_armv7.crash
@@ -2,34 +2,34 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a9a9c5
+Exception Codes: BUS_NOOP at 0xa5a5a9c5
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xa5a9a9c5.
+Attempted to dereference garbage pointer 0xa5a5a9c5.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x4280ba12          _cache_getImp
-1   libobjc.A.dylib                 0x428059d1          _lookUpImpOrForward
-2   libobjc.A.dylib                 0x42805873          _class_lookupMethodAndLoadCache3
-3   libobjc.A.dylib                 0x4280bcfb          _objc_msgSend_uncached
-4   CrashLibiOS                     0x16bd43            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
-5   CrashProbeiOS                   0x57e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-6   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-7   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-8   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-9   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-10  UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-11  UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-12  UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-13  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-14  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-15  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-17  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-18  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-19  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-20  GraphicsServices                0x462c5ac9          _GSEventRunModal
-21  UIKit                           0x4c41a189          _UIApplicationMain
-22  CrashProbeiOS                   0x5714f             main (main.m:16)
+0   libobjc.A.dylib                 0x449c3a12          _cache_getImp
+1   libobjc.A.dylib                 0x449bd9d1          _lookUpImpOrForward
+2   libobjc.A.dylib                 0x449bd873          __class_lookupMethodAndLoadCache3
+3   libobjc.A.dylib                 0x449c3cfb          __objc_msgSend_uncached
+4   CrashLibiOS                     0x173d43            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+5   CrashProbeiOS                   0x5fe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+6   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+7   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+8   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+9   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+10  UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+11  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+12  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+13  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+14  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+15  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+17  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+18  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+19  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+20  GraphicsServices                0x4847dac9          _GSEventRunModal
+21  UIKit                           0x4e5d2189          _UIApplicationMain
+22  CrashProbeiOS                   0x5f14f             main (main.m:16)

--- a/ios/17/data.json
+++ b/ios/17/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/18/_sentry_arm64.crash
+++ b/ios/18/_sentry_arm64.crash
@@ -9,6 +9,6 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10011c158         CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
-1   CrashLibiOS                     0x10011c210         CRLFramelessDWARF_test
+0   CrashLibiOS                     0x10008c158         CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                     0x10008c210         CRLFramelessDWARF_test
 <span class="cp-wrong">Missing frames</span>

--- a/ios/18/_sentry_arm64.crash
+++ b/ios/18/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Crashed Thread: 0
 

--- a/ios/18/_sentry_arm64.crash
+++ b/ios/18/_sentry_arm64.crash
@@ -1,0 +1,11 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x10011c158         CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                     0x10011c210         CRLFramelessDWARF_test
+<span class="cp-wrong">Missing frames</span>

--- a/ios/18/_sentry_armv7.crash
+++ b/ios/18/_sentry_armv7.crash
@@ -9,6 +9,6 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100d52            CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
-1   CrashLibiOS                     0x100dc0            CRLFramelessDWARF_test
+0   CrashLibiOS                     0x123d52            CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                     0x123dc0            CRLFramelessDWARF_test
 <span class="cp-wrong">Missing frames</span>

--- a/ios/18/_sentry_armv7.crash
+++ b/ios/18/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
 Crashed Thread: 0
 

--- a/ios/18/_sentry_armv7.crash
+++ b/ios/18/_sentry_armv7.crash
@@ -1,0 +1,11 @@
+Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x100d52            CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                     0x100dc0            CRLFramelessDWARF_test
+<span class="cp-wrong">Missing frames</span>

--- a/ios/18/data.json
+++ b/ios/18/data.json
@@ -33,6 +33,10 @@
     "Bugsnag": {
       "armv7": "wrong",
       "arm64": "wrong"
+    },
+    "Sentry": {
+      "armv7": "incomplete",
+      "arm64": "incomplete"
     }
   }
 }

--- a/ios/19/_sentry_arm64.crash
+++ b/ios/19/_sentry_arm64.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x10011c2dc         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashLibiOS                     0x10011c2c0         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:42)
+2   CrashProbeiOS                   0x200100220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         __handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         GSEventRunModal
+20  UIKit                           0x31d13a7fc         -[UIApplication _run]
+21  UIKit                           0x31d135534         UIApplicationMain
+22  CrashProbeiOS                   0x2000ff2a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/19/_sentry_arm64.crash
+++ b/ios/19/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Crashed Thread: 0
 
@@ -6,27 +9,27 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10011c2dc         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-1   CrashLibiOS                     0x10011c2c0         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:42)
-2   CrashProbeiOS                   0x200100220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x10004c2dc         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashLibiOS                     0x10004c2c0         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:42)
+2   CrashProbeiOS                   0x200020220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         __handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         GSEventRunModal
+13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         ___handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         _GSEventRunModal
 20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         UIApplicationMain
-22  CrashProbeiOS                   0x2000ff2a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         start
+21  UIKit                           0x31d135534         _UIApplicationMain
+22  CrashProbeiOS                   0x20001f2a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/19/_sentry_arm64.crash
+++ b/ios/19/_sentry_arm64.crash
@@ -9,27 +9,26 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10004c2dc         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-1   CrashLibiOS                     0x10004c2c0         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:42)
-2   CrashProbeiOS                   0x200020220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         ___handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         _GSEventRunModal
-20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         _UIApplicationMain
-22  CrashProbeiOS                   0x20001f2a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x10011c2dc         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashProbeiOS                   0x2000f8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x31c457130         ___handleEventQueue
+14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+18  GraphicsServices                0x313234198         _GSEventRunModal
+19  UIKit                           0x31bcde7fc         -[UIApplication _run]
+20  UIKit                           0x31bcd9534         _UIApplicationMain
+21  CrashProbeiOS                   0x2000f72a4         main (main.m:16)
+22  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/19/_sentry_armv7.crash
+++ b/ios/19/_sentry_armv7.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x4ce52             -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashLibiOS                     0x4ce4f             -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:49)
+2   CrashProbeiOS                   0x38e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x4114968b          __handleEventQueue
+15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+20  GraphicsServices                0x3966fbfd          GSEventRunModal
+21  UIKit                           0x40a1a82f          -[UIApplication _run]
+22  UIKit                           0x40a14f61          UIApplicationMain
+23  CrashProbeiOS                   0x3814f             main (main.m:16)

--- a/ios/19/_sentry_armv7.crash
+++ b/ios/19/_sentry_armv7.crash
@@ -9,23 +9,22 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x219e52            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-1   CrashLibiOS                     0x219e4f            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:49)
-2   CrashProbeiOS                   0x105e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-17  GraphicsServices                0x462c5ac9          _GSEventRunModal
-18  UIKit                           0x4c41a189          _UIApplicationMain
-19  CrashProbeiOS                   0x10514f            main (main.m:16)
+0   CrashLibiOS                     0x1bfe52            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashProbeiOS                   0xabe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+16  GraphicsServices                0x4847dac9          _GSEventRunModal
+17  UIKit                           0x4e5d2189          _UIApplicationMain
+18  CrashProbeiOS                   0xab14f             main (main.m:16)

--- a/ios/19/_sentry_armv7.crash
+++ b/ios/19/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
 Crashed Thread: 0
 
@@ -6,27 +9,23 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x4ce52             -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-1   CrashLibiOS                     0x4ce4f             -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:49)
-2   CrashProbeiOS                   0x38e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x4114968b          __handleEventQueue
-15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-20  GraphicsServices                0x3966fbfd          GSEventRunModal
-21  UIKit                           0x40a1a82f          -[UIApplication _run]
-22  UIKit                           0x40a14f61          UIApplicationMain
-23  CrashProbeiOS                   0x3814f             main (main.m:16)
+0   CrashLibiOS                     0x219e52            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashLibiOS                     0x219e4f            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:49)
+2   CrashProbeiOS                   0x105e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+17  GraphicsServices                0x462c5ac9          _GSEventRunModal
+18  UIKit                           0x4c41a189          _UIApplicationMain
+19  CrashProbeiOS                   0x10514f            main (main.m:16)

--- a/ios/19/data.json
+++ b/ios/19/data.json
@@ -32,6 +32,10 @@
     "Bugsnag": {
       "armv7": "complete",
       "arm64": "complete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }

--- a/ios/20/_sentry_arm64.crash
+++ b/ios/20/_sentry_arm64.crash
@@ -10,18 +10,18 @@ Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
 
 <span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
 Thread 1 name:
-0   libsystem_kernel.dylib          0x30f2ffa88         ___workq_kernreturn
-1   libsystem_pthread.dylib         0x30f4a5344         __pthread_wqthread
+0   libsystem_kernel.dylib          0x30dea3a88         ___workq_kernreturn
+1   libsystem_pthread.dylib         0x30e049160         __pthread_wqthread
 
 Thread 2 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x30f2e1188         _mach_msg_trap
-1   libsystem_kernel.dylib          0x30f2e0ff8         _mach_msg
-2   CoreFoundation                  0x3111ff5d0         ___CFRunLoopServiceMachPort
-3   CoreFoundation                  0x3111fd1ec         ___CFRunLoopRun
-4   CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-5   Foundation                      0x3127a226c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
-6   Foundation                      0x3127c2dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
-7   UIKit                           0x31daaec38         -[UIEventFetcher threadMain]
-8   Foundation                      0x31289fe68         ___NSThread__start__
-9   libsystem_pthread.dylib         0x30f4a7850         __pthread_body
-10  libsystem_pthread.dylib         0x30f4a7760         __pthread_start
+0   libsystem_kernel.dylib          0x30de85188         _mach_msg_trap
+1   libsystem_kernel.dylib          0x30de84ff8         _mach_msg
+2   CoreFoundation                  0x30fda35d0         ___CFRunLoopServiceMachPort
+3   CoreFoundation                  0x30fda11ec         ___CFRunLoopRun
+4   CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+5   Foundation                      0x31134626c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+6   Foundation                      0x311366dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
+7   UIKit                           0x31c652c38         -[UIEventFetcher threadMain]
+8   Foundation                      0x311443e68         ___NSThread__start__
+9   libsystem_pthread.dylib         0x30e04b850         __pthread_body
+10  libsystem_pthread.dylib         0x30e04b760         __pthread_start

--- a/ios/20/_sentry_arm64.crash
+++ b/ios/20/_sentry_arm64.crash
@@ -1,0 +1,20 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xa5a5a5a5a5a5a5a5
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
+
+<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
+Thread 1 name: com.apple.uikit.eventfetch-thread
+0   libsystem_kernel.dylib          0x30f2e1188         mach_msg_trap
+1   libsystem_kernel.dylib          0x30f2e0ff8         mach_msg
+2   CoreFoundation                  0x3111ff5d0         __CFRunLoopServiceMachPort
+3   CoreFoundation                  0x3111fd1ec         __CFRunLoopRun
+4   CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+5   Foundation                      0x3127a226c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+6   Foundation                      0x3127c2dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
+7   UIKit                           0x31daaec38         -[UIEventFetcher threadMain]
+8   Foundation                      0x31289fe68         __NSThread__start__
+9   libsystem_pthread.dylib         0x30f4a7850         _pthread_body
+10  libsystem_pthread.dylib         0x30f4a7760         _pthread_start

--- a/ios/20/_sentry_arm64.crash
+++ b/ios/20/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0xa5a5a5a5a5a5a5a5
 Crashed Thread: 0
@@ -6,15 +9,19 @@ Application Specific Information:
 Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
 
 <span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
-Thread 1 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x30f2e1188         mach_msg_trap
-1   libsystem_kernel.dylib          0x30f2e0ff8         mach_msg
-2   CoreFoundation                  0x3111ff5d0         __CFRunLoopServiceMachPort
-3   CoreFoundation                  0x3111fd1ec         __CFRunLoopRun
-4   CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+Thread 1 name:
+0   libsystem_kernel.dylib          0x30f2ffa88         ___workq_kernreturn
+1   libsystem_pthread.dylib         0x30f4a5344         __pthread_wqthread
+
+Thread 2 name: com.apple.uikit.eventfetch-thread
+0   libsystem_kernel.dylib          0x30f2e1188         _mach_msg_trap
+1   libsystem_kernel.dylib          0x30f2e0ff8         _mach_msg
+2   CoreFoundation                  0x3111ff5d0         ___CFRunLoopServiceMachPort
+3   CoreFoundation                  0x3111fd1ec         ___CFRunLoopRun
+4   CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
 5   Foundation                      0x3127a226c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
 6   Foundation                      0x3127c2dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
 7   UIKit                           0x31daaec38         -[UIEventFetcher threadMain]
-8   Foundation                      0x31289fe68         __NSThread__start__
-9   libsystem_pthread.dylib         0x30f4a7850         _pthread_body
-10  libsystem_pthread.dylib         0x30f4a7760         _pthread_start
+8   Foundation                      0x31289fe68         ___NSThread__start__
+9   libsystem_pthread.dylib         0x30f4a7850         __pthread_body
+10  libsystem_pthread.dylib         0x30f4a7760         __pthread_start

--- a/ios/20/_sentry_armv7.crash
+++ b/ios/20/_sentry_armv7.crash
@@ -1,0 +1,21 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xa5a5a5a4
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xa5a5a5a4.
+
+<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
+Thread 1 name: com.apple.uikit.eventfetch-thread
+0   libsystem_kernel.dylib          0x3583383c          mach_msg_trap
+1   libsystem_kernel.dylib          0x3583362f          mach_msg
+2   CoreFoundation                  0x367c7869          __CFRunLoopServiceMachPort
+3   CoreFoundation                  0x367c5b67          __CFRunLoopRun
+4   CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+5   CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+6   Foundation                      0x379790db          -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+7   Foundation                      0x37997df1          -[NSRunLoop(NSRunLoop) runUntilDate:]
+8   UIKit                           0x41322cb3          -[UIEventFetcher threadMain]
+9   Foundation                      0x37a620d1          __NSThread__start__
+10  libsystem_pthread.dylib         0x359c5a17          _pthread_body
+11  libsystem_pthread.dylib         0x359c593d          _pthread_start

--- a/ios/20/_sentry_armv7.crash
+++ b/ios/20/_sentry_armv7.crash
@@ -10,9 +10,9 @@ Attempted to dereference garbage pointer 0xa5a5a5a4.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x19deb7            -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:54)
+0   CrashLibiOS                     0x141eb7            -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:54)
 
 Thread 1 name:
-0   libsystem_kernel.dylib          0x431d22f8          _kevent_qos
-1   libdispatch.dylib               0x42fbcd61          __dispatch_mgr_invoke
-2   libdispatch.dylib               0x42fbcabf          __dispatch_mgr_thread$VARIANT$mp
+0   libsystem_kernel.dylib          0x4538a2f8          _kevent_qos
+1   libdispatch.dylib               0x45174d61          __dispatch_mgr_invoke
+2   libdispatch.dylib               0x45174abf          __dispatch_mgr_thread$VARIANT$mp

--- a/ios/20/_sentry_armv7.crash
+++ b/ios/20/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0xa5a5a5a4
 Crashed Thread: 0
@@ -5,17 +8,11 @@ Crashed Thread: 0
 Application Specific Information:
 Attempted to dereference garbage pointer 0xa5a5a5a4.
 
-<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
-Thread 1 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x3583383c          mach_msg_trap
-1   libsystem_kernel.dylib          0x3583362f          mach_msg
-2   CoreFoundation                  0x367c7869          __CFRunLoopServiceMachPort
-3   CoreFoundation                  0x367c5b67          __CFRunLoopRun
-4   CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-5   CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-6   Foundation                      0x379790db          -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
-7   Foundation                      0x37997df1          -[NSRunLoop(NSRunLoop) runUntilDate:]
-8   UIKit                           0x41322cb3          -[UIEventFetcher threadMain]
-9   Foundation                      0x37a620d1          __NSThread__start__
-10  libsystem_pthread.dylib         0x359c5a17          _pthread_body
-11  libsystem_pthread.dylib         0x359c593d          _pthread_start
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x19deb7            -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:54)
+
+Thread 1 name:
+0   libsystem_kernel.dylib          0x431d22f8          _kevent_qos
+1   libdispatch.dylib               0x42fbcd61          __dispatch_mgr_invoke
+2   libdispatch.dylib               0x42fbcabf          __dispatch_mgr_thread$VARIANT$mp

--- a/ios/20/data.json
+++ b/ios/20/data.json
@@ -31,6 +31,10 @@
     "Bugsnag": {
       "armv7": "wrong",
       "arm64": "wrong"
+    },
+    "Sentry": {
+      "armv7": "wrong",
+      "arm64": "wrong"
     }
   }
 }

--- a/ios/20/data.json
+++ b/ios/20/data.json
@@ -33,7 +33,7 @@
       "arm64": "wrong"
     },
     "Sentry": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "wrong"
     }
   }

--- a/ios/21/_sentry_arm64.crash
+++ b/ios/21/_sentry_arm64.crash
@@ -1,0 +1,24 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xa5a5a5a5a5a5a5a5
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
+
+<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
+Thread 1 name:
+0   libsystem_kernel.dylib          0x30f2ffa88         __workq_kernreturn
+1   libsystem_pthread.dylib         0x30f4a5160         _pthread_wqthread
+
+Thread 2 name: com.apple.uikit.eventfetch-thread
+0   libsystem_kernel.dylib          0x30f2e1188         mach_msg_trap
+1   libsystem_kernel.dylib          0x30f2e0ff8         mach_msg
+2   CoreFoundation                  0x3111ff5d0         __CFRunLoopServiceMachPort
+3   CoreFoundation                  0x3111fd1ec         __CFRunLoopRun
+4   CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+5   Foundation                      0x3127a226c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+6   Foundation                      0x3127c2dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
+7   UIKit                           0x31daaec38         -[UIEventFetcher threadMain]
+8   Foundation                      0x31289fe68         __NSThread__start__
+9   libsystem_pthread.dylib         0x30f4a7850         _pthread_body
+10  libsystem_pthread.dylib         0x30f4a7760         _pthread_start

--- a/ios/21/_sentry_arm64.crash
+++ b/ios/21/_sentry_arm64.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0xa5a5a5a5a5a5a5a5
 Crashed Thread: 0
@@ -7,18 +10,18 @@ Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
 
 <span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
 Thread 1 name:
-0   libsystem_kernel.dylib          0x30f2ffa88         __workq_kernreturn
-1   libsystem_pthread.dylib         0x30f4a5160         _pthread_wqthread
+0   libsystem_kernel.dylib          0x30f2ffa88         ___workq_kernreturn
+1   libsystem_pthread.dylib         0x30f4a5344         __pthread_wqthread
 
 Thread 2 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x30f2e1188         mach_msg_trap
-1   libsystem_kernel.dylib          0x30f2e0ff8         mach_msg
-2   CoreFoundation                  0x3111ff5d0         __CFRunLoopServiceMachPort
-3   CoreFoundation                  0x3111fd1ec         __CFRunLoopRun
-4   CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+0   libsystem_kernel.dylib          0x30f2e1188         _mach_msg_trap
+1   libsystem_kernel.dylib          0x30f2e0ff8         _mach_msg
+2   CoreFoundation                  0x3111ff5d0         ___CFRunLoopServiceMachPort
+3   CoreFoundation                  0x3111fd1ec         ___CFRunLoopRun
+4   CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
 5   Foundation                      0x3127a226c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
 6   Foundation                      0x3127c2dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
 7   UIKit                           0x31daaec38         -[UIEventFetcher threadMain]
-8   Foundation                      0x31289fe68         __NSThread__start__
-9   libsystem_pthread.dylib         0x30f4a7850         _pthread_body
-10  libsystem_pthread.dylib         0x30f4a7760         _pthread_start
+8   Foundation                      0x31289fe68         ___NSThread__start__
+9   libsystem_pthread.dylib         0x30f4a7850         __pthread_body
+10  libsystem_pthread.dylib         0x30f4a7760         __pthread_start

--- a/ios/21/_sentry_arm64.crash
+++ b/ios/21/_sentry_arm64.crash
@@ -10,18 +10,18 @@ Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
 
 <span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
 Thread 1 name:
-0   libsystem_kernel.dylib          0x30f2ffa88         ___workq_kernreturn
-1   libsystem_pthread.dylib         0x30f4a5344         __pthread_wqthread
+0   libsystem_kernel.dylib          0x30dea3a88         ___workq_kernreturn
+1   libsystem_pthread.dylib         0x30e049160         __pthread_wqthread
 
 Thread 2 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x30f2e1188         _mach_msg_trap
-1   libsystem_kernel.dylib          0x30f2e0ff8         _mach_msg
-2   CoreFoundation                  0x3111ff5d0         ___CFRunLoopServiceMachPort
-3   CoreFoundation                  0x3111fd1ec         ___CFRunLoopRun
-4   CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-5   Foundation                      0x3127a226c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
-6   Foundation                      0x3127c2dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
-7   UIKit                           0x31daaec38         -[UIEventFetcher threadMain]
-8   Foundation                      0x31289fe68         ___NSThread__start__
-9   libsystem_pthread.dylib         0x30f4a7850         __pthread_body
-10  libsystem_pthread.dylib         0x30f4a7760         __pthread_start
+0   libsystem_kernel.dylib          0x30de85188         _mach_msg_trap
+1   libsystem_kernel.dylib          0x30de84ff8         _mach_msg
+2   CoreFoundation                  0x30fda35d0         ___CFRunLoopServiceMachPort
+3   CoreFoundation                  0x30fda11ec         ___CFRunLoopRun
+4   CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+5   Foundation                      0x31134626c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+6   Foundation                      0x311366dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
+7   UIKit                           0x31c652c38         -[UIEventFetcher threadMain]
+8   Foundation                      0x311443e68         ___NSThread__start__
+9   libsystem_pthread.dylib         0x30e04b850         __pthread_body
+10  libsystem_pthread.dylib         0x30e04b760         __pthread_start

--- a/ios/21/_sentry_armv7.crash
+++ b/ios/21/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
 Exception Codes: BUS_NOOP at 0xa5a5a5a4
 Crashed Thread: 0
@@ -5,17 +8,11 @@ Crashed Thread: 0
 Application Specific Information:
 Attempted to dereference garbage pointer 0xa5a5a5a4.
 
-<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
-Thread 1 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x3583383c          mach_msg_trap
-1   libsystem_kernel.dylib          0x3583362f          mach_msg
-2   CoreFoundation                  0x367c7869          __CFRunLoopServiceMachPort
-3   CoreFoundation                  0x367c5b67          __CFRunLoopRun
-4   CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-5   CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-6   Foundation                      0x379790db          -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
-7   Foundation                      0x37997df1          -[NSRunLoop(NSRunLoop) runUntilDate:]
-8   UIKit                           0x41322cb3          -[UIEventFetcher threadMain]
-9   Foundation                      0x37a620d1          __NSThread__start__
-10  libsystem_pthread.dylib         0x359c5a17          _pthread_body
-11  libsystem_pthread.dylib         0x359c593d          _pthread_start
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x1a3f1f            -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:54)
+
+Thread 1 name:
+0   libsystem_kernel.dylib          0x431d22f8          _kevent_qos
+1   libdispatch.dylib               0x42fbcd61          __dispatch_mgr_invoke
+2   libdispatch.dylib               0x42fbcabf          __dispatch_mgr_thread$VARIANT$mp

--- a/ios/21/_sentry_armv7.crash
+++ b/ios/21/_sentry_armv7.crash
@@ -10,9 +10,9 @@ Attempted to dereference garbage pointer 0xa5a5a5a4.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1a3f1f            -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:54)
+0   CrashLibiOS                     0x212f1f            -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:54)
 
 Thread 1 name:
-0   libsystem_kernel.dylib          0x431d22f8          _kevent_qos
-1   libdispatch.dylib               0x42fbcd61          __dispatch_mgr_invoke
-2   libdispatch.dylib               0x42fbcabf          __dispatch_mgr_thread$VARIANT$mp
+0   libsystem_kernel.dylib          0x4538a2f8          _kevent_qos
+1   libdispatch.dylib               0x45174d61          __dispatch_mgr_invoke
+2   libdispatch.dylib               0x45174abf          __dispatch_mgr_thread$VARIANT$mp

--- a/ios/21/_sentry_armv7.crash
+++ b/ios/21/_sentry_armv7.crash
@@ -1,0 +1,21 @@
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0xa5a5a5a4
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xa5a5a5a4.
+
+<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
+Thread 1 name: com.apple.uikit.eventfetch-thread
+0   libsystem_kernel.dylib          0x3583383c          mach_msg_trap
+1   libsystem_kernel.dylib          0x3583362f          mach_msg
+2   CoreFoundation                  0x367c7869          __CFRunLoopServiceMachPort
+3   CoreFoundation                  0x367c5b67          __CFRunLoopRun
+4   CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+5   CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+6   Foundation                      0x379790db          -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+7   Foundation                      0x37997df1          -[NSRunLoop(NSRunLoop) runUntilDate:]
+8   UIKit                           0x41322cb3          -[UIEventFetcher threadMain]
+9   Foundation                      0x37a620d1          __NSThread__start__
+10  libsystem_pthread.dylib         0x359c5a17          _pthread_body
+11  libsystem_pthread.dylib         0x359c593d          _pthread_start

--- a/ios/21/data.json
+++ b/ios/21/data.json
@@ -31,6 +31,10 @@
     "Bugsnag": {
       "armv7": "wrong",
       "arm64": "wrong"
+    },
+    "Sentry": {
+      "armv7": "wrong",
+      "arm64": "wrong"
     }
   }
 }

--- a/ios/21/data.json
+++ b/ios/21/data.json
@@ -33,7 +33,7 @@
       "arm64": "wrong"
     },
     "Sentry": {
-      "armv7": "wrong",
+      "armv7": "complete",
       "arm64": "wrong"
     }
   }

--- a/ios/22/_sentry_arm64.crash
+++ b/ios/22/_sentry_arm64.crash
@@ -5,31 +5,31 @@ Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 771328, Subcode 8
+Exception 6, Code 214272, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000bc500         @objc CRLCrashSwift.crash() -> ()
-1   CrashLibiOS                     0x1000bc500         CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
-2   CrashProbeiOS                   0x2000a0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
-9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
-12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         ___handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         _GSEventRunModal
-20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         _UIApplicationMain
-22  CrashProbeiOS                   0x20009f2a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         _start
+0   CrashLibiOS                     0x100034500         [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+1   CrashLibiOS                     0x100034500         @objc CRLCrashSwift.crash() -> ()
+2   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
+9   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
+12  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
+13  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31c457130         ___handleEventQueue
+15  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
+17  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
+18  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
+19  GraphicsServices                0x313234198         _GSEventRunModal
+20  UIKit                           0x31bcde7fc         -[UIApplication _run]
+21  UIKit                           0x31bcd9534         _UIApplicationMain
+22  CrashProbeiOS                   0x20000f2a4         main (main.m:16)
+23  libdyld.dylib                   0x30dc9a5b8         _start

--- a/ios/22/_sentry_arm64.crash
+++ b/ios/22/_sentry_arm64.crash
@@ -1,32 +1,35 @@
+OS Version: iOS 10.2.1 (14D27)
+Report Version: 104
+
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 492800, Subcode 8
+Exception 6, Code 771328, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100078500         @objc CRLCrashSwift.crash() -> ()
-1   CrashLibiOS                     0x100078500         CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
-2   CrashProbeiOS                   0x200044220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+0   CrashLibiOS                     0x1000bc500         @objc CRLCrashSwift.crash() -> ()
+1   CrashLibiOS                     0x1000bc500         CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+2   CrashProbeiOS                   0x2000a0220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
 4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
 5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
 6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+7   UIKit                           0x31d68f628         __UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         __UIGestureEnvironmentUpdate
 9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
 10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
 11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
 12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
-13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31d8b3130         __handleEventQueue
-15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
-17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
-18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
-19  GraphicsServices                0x314690198         GSEventRunModal
+13  UIKit                           0x31d8b975c         ___dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         ___handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         ___CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         ___CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         _CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         _GSEventRunModal
 20  UIKit                           0x31d13a7fc         -[UIApplication _run]
-21  UIKit                           0x31d135534         UIApplicationMain
-22  CrashProbeiOS                   0x2000432a4         main (main.m:16)
-23  libdyld.dylib                   0x30f0f65b8         start
+21  UIKit                           0x31d135534         _UIApplicationMain
+22  CrashProbeiOS                   0x20009f2a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         _start

--- a/ios/22/_sentry_arm64.crash
+++ b/ios/22/_sentry_arm64.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BREAKPOINT
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 6, Code 492800, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x100078500         @objc CRLCrashSwift.crash() -> ()
+1   CrashLibiOS                     0x100078500         CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+2   CrashProbeiOS                   0x200044220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x31d104d30         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x31d104cb0         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x31d0ef128         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x31d10459c         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x31d68f628         _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x31d68b6c0         _UIGestureEnvironmentUpdate
+9   UIKit                           0x31d68b1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x31d68a49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31d0ff30c         -[UIWindow sendEvent:]
+12  UIKit                           0x31d0cfda0         -[UIApplication sendEvent:]
+13  UIKit                           0x31d8b975c         __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x31d8b3130         __handleEventQueue
+15  CoreFoundation                  0x3111ffb5c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x3111ff4a4         __CFRunLoopDoSources0
+17  CoreFoundation                  0x3111fd0a4         __CFRunLoopRun
+18  CoreFoundation                  0x31112b2b8         CFRunLoopRunSpecific
+19  GraphicsServices                0x314690198         GSEventRunModal
+20  UIKit                           0x31d13a7fc         -[UIApplication _run]
+21  UIKit                           0x31d135534         UIApplicationMain
+22  CrashProbeiOS                   0x2000432a4         main (main.m:16)
+23  libdyld.dylib                   0x30f0f65b8         start

--- a/ios/22/_sentry_arm64.crash
+++ b/ios/22/_sentry_arm64.crash
@@ -9,8 +9,8 @@ Exception 6, Code 214272, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100034500         [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
-1   CrashLibiOS                     0x100034500         @objc CRLCrashSwift.crash() -> ()
+<span class="cp-wrong">0   CrashLibiOS                     0x100034500         [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)</span>
+<span class="cp-wrong">1   CrashLibiOS                     0x100034500         @objc CRLCrashSwift.crash() -> ()</span>
 2   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
 3   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
 4   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]

--- a/ios/22/_sentry_armv7.crash
+++ b/ios/22/_sentry_armv7.crash
@@ -1,0 +1,32 @@
+Exception Type: EXC_BREAKPOINT
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 6, Code 1, Subcode 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLibiOS                     0x23fe8             @objc CRLCrashSwift.crash() -> ()
+1   CrashLibiOS                     0x23fe8             CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+2   CrashProbeiOS                   0xfe19              -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
+9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
+12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
+13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x4114968b          __handleEventQueue
+15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
+17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
+18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
+19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
+20  GraphicsServices                0x3966fbfd          GSEventRunModal
+21  UIKit                           0x40a1a82f          -[UIApplication _run]
+22  UIKit                           0x40a14f61          UIApplicationMain
+23  CrashProbeiOS                   0xf14f              main (main.m:16)

--- a/ios/22/_sentry_armv7.crash
+++ b/ios/22/_sentry_armv7.crash
@@ -9,23 +9,23 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x189fe8            @objc CRLCrashSwift.crash() -> ()
-1   CrashLibiOS                     0x189fe8            CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
-2   CrashProbeiOS                   0x75e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
-10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
-11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
-15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
-17  GraphicsServices                0x462c5ac9          _GSEventRunModal
-18  UIKit                           0x4c41a189          _UIApplicationMain
-19  CrashProbeiOS                   0x7514f             main (main.m:16)
+<span class="cp-wrong">0   CrashLibiOS                     0x1a0fe8            [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)</span>
+<span class="cp-wrong">1   CrashLibiOS                     0x1a0fe8            @objc CRLCrashSwift.crash() -> ()</span>
+2   CrashProbeiOS                   0x8ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
+10  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
+11  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
+15  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
+17  GraphicsServices                0x4847dac9          _GSEventRunModal
+18  UIKit                           0x4e5d2189          _UIApplicationMain
+19  CrashProbeiOS                   0x8c14f             main (main.m:16)

--- a/ios/22/_sentry_armv7.crash
+++ b/ios/22/_sentry_armv7.crash
@@ -1,3 +1,6 @@
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
@@ -6,27 +9,23 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x23fe8             @objc CRLCrashSwift.crash() -> ()
-1   CrashLibiOS                     0x23fe8             CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
-2   CrashProbeiOS                   0xfe19              -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x409e46bd          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x409e464b          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x409ce7e7          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x409e3f73          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x40f4620b          _UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x40f42851          _UIGestureEnvironmentUpdate
-9   UIKit                           0x40f42403          -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x40f41847          -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x409de68d          -[UIWindow sendEvent:]
-12  UIKit                           0x409af53d          -[UIApplication sendEvent:]
-13  UIKit                           0x4114f9e9          __dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x4114968b          __handleEventQueue
-15  CoreFoundation                  0x367c7c8b          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x367c7795          __CFRunLoopDoSources0
-17  CoreFoundation                  0x367c5a6b          __CFRunLoopRun
-18  CoreFoundation                  0x36715073          CFRunLoopRunSpecific
-19  CoreFoundation                  0x36714e81          CFRunLoopRunInMode
-20  GraphicsServices                0x3966fbfd          GSEventRunModal
-21  UIKit                           0x40a1a82f          -[UIApplication _run]
-22  UIKit                           0x40a14f61          UIApplicationMain
-23  CrashProbeiOS                   0xf14f              main (main.m:16)
+0   CrashLibiOS                     0x189fe8            @objc CRLCrashSwift.crash() -> ()
+1   CrashLibiOS                     0x189fe8            CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+2   CrashProbeiOS                   0x75e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4c3e9755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4c3e96e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4c3d16d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4c3e9005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4c3a2f25          __UIGestureRecognizerUpdate
+8   UIKit                           0x4c3e1ec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4c3e167b          -[UIWindow sendEvent:]
+10  UIKit                           0x4c3b2125          -[UIApplication sendEvent:]
+11  UIKit                           0x4c3b06d3          __UIApplicationHandleEventQueue
+12  CoreFoundation                  0x43797dff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x437979ed          ___CFRunLoopDoSources0
+14  CoreFoundation                  0x43795d5b          ___CFRunLoopRun
+15  CoreFoundation                  0x436e5229          _CFRunLoopRunSpecific
+16  CoreFoundation                  0x436e5015          _CFRunLoopRunInMode
+17  GraphicsServices                0x462c5ac9          _GSEventRunModal
+18  UIKit                           0x4c41a189          _UIApplicationMain
+19  CrashProbeiOS                   0x7514f             main (main.m:16)

--- a/ios/22/data.json
+++ b/ios/22/data.json
@@ -34,8 +34,8 @@
       "arm64": "incomplete"
     },
     "Sentry": {
-      "armv7": "complete",
-      "arm64": "complete"
+      "armv7": "incomplete",
+      "arm64": "incomplete"
     }
   }
 }

--- a/ios/22/data.json
+++ b/ios/22/data.json
@@ -33,10 +33,6 @@
       "armv7": "incomplete",
       "arm64": "incomplete"
     },
-    "Bugsnag": {
-      "armv7": "complete",
-      "arm64": "incomplete"
-    },
     "Sentry": {
       "armv7": "complete",
       "arm64": "complete"

--- a/ios/22/data.json
+++ b/ios/22/data.json
@@ -32,6 +32,14 @@
     "Bugsnag": {
       "armv7": "incomplete",
       "arm64": "incomplete"
+    },
+    "Bugsnag": {
+      "armv7": "complete",
+      "arm64": "incomplete"
+    },
+    "Sentry": {
+      "armv7": "complete",
+      "arm64": "complete"
     }
   }
 }


### PR DESCRIPTION
Provider name: Sentry
Repository URL: https://github.com/getsentry/CrashProbe
URL to the data: https://sentry.io/sentry-jj/crashprobe/
Username and password for the account: `daniel+crashprobe@sentry.io:9p7U{sB64h7n2{]igCq&*/gw`

Date of testing: 04/03/2017
SDK-Version: 2.1.7 (Swift 3)
Logo: https://sentry.io/branding/
Xcode Version 8.2.1 (8C1002)

Test environment per architecture:
arm7: iPad mini (P107AP), iOS 9.3.5
arm64: iPod Touch 6G (N102AP), iOS 10.2.1