### PR TITLE
Updated results for Sentry v3.0.7 and XCode 8.3.2

### DIFF
--- a/ios/01/_sentry_arm64.crash
+++ b/ios/01/_sentry_arm64.crash
@@ -1,8 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
-Exception Codes: SEGV_NOOP at 0x1
+Exception Codes: SEGV_NOOP at 0x0000000000000001
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,29 +10,29 @@ Attempted to dereference garbage pointer 0x1.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_platform.dylib        0x30e03bf44         __platform_memmove
-1   libsystem_pthread.dylib         0x30e04cbe0         [inlined] _pthread_getname_np
-2   libsystem_pthread.dylib         0x30e04cbe0         _pthread_getname_np
-3   CrashLibiOS                     0x1000a747c         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4   CrashProbeiOS                   0x20008c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-11  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-14  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-15  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31c457130         ___handleEventQueue
-17  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-19  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-20  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-21  GraphicsServices                0x313234198         _GSEventRunModal
-22  UIKit                           0x31bcde7fc         -[UIApplication _run]
-23  UIKit                           0x31bcd9534         _UIApplicationMain
-24  CrashProbeiOS                   0x20008b3cc         main (main.m:16)
-25  libdyld.dylib                   0x30dc9a5b8         _start
+0   libsystem_platform.dylib        0x30a383ea4         _platform_memmove
+1   libsystem_pthread.dylib         0x30a394a0c         [inlined] pthread_getname_np
+2   libsystem_pthread.dylib         0x30a394a0c         pthread_getname_np
+3   CrashLibiOS                     0x1000cf414         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0x2000b82bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+11  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+14  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+15  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x318c58770         __handleEventQueue
+17  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+18  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+19  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+20  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+21  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+22  GraphicsServices                0x30f490074         GSEventRunModal
+23  UIKit                           0x3184c9058         UIApplicationMain
+24  CrashProbeiOS                   0x2000b7330         main (main.m:16)
+25  libdyld.dylib                   0x309fe259c         start

--- a/ios/01/_sentry_armv7.crash
+++ b/ios/01/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x1
+Exception Codes: BUS_NOOP at 0x0000000000000001
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,25 +10,25 @@ Attempted to dereference garbage pointer 0x1.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_platform.dylib        0x454df1a4          __platform_memmove$VARIANT$CortexA9
-1   libsystem_pthread.dylib         0x454ec3c9          [inlined] _pthread_getname_np
-2   libsystem_pthread.dylib         0x454ec3c9          _pthread_getname_np
-3   CrashLibiOS                     0x21d47b            -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
-4   CrashProbeiOS                   0x109e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-10  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-11  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-12  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-13  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-14  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-16  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-17  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-18  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-19  GraphicsServices                0x4847dac9          _GSEventRunModal
-20  UIKit                           0x4e5d2189          _UIApplicationMain
-21  CrashProbeiOS                   0x10914f            main (main.m:16)
+0   libsystem_platform.dylib        0x451a31a4          _platform_memmove$VARIANT$CortexA9
+1   libsystem_pthread.dylib         0x451b03c9          [inlined] pthread_getname_np
+2   libsystem_pthread.dylib         0x451b03c9          pthread_getname_np
+3   CrashLibiOS                     0x1e745b            -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+4   CrashProbeiOS                   0xd3e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+10  UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+11  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+12  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+13  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+14  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+16  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+17  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+18  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+19  GraphicsServices                0x48141ac9          GSEventRunModal
+20  UIKit                           0x4e296189          UIApplicationMain
+21  CrashProbeiOS                   0xd30ff             main (main.m:16)

--- a/ios/02/_sentry_arm64.crash
+++ b/ios/02/_sentry_arm64.crash
@@ -1,1 +1,22 @@
-<span class="cp-wrong">No report</span>
+OS Version: iOS 10.3.2 (14F89)
+Report Version: 104
+
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+kaboom_exception*
+
+Thread 1 name: com.apple.uikit.eventfetch-thread
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+0   libsystem_kernel.dylib          0x30a1c9224         mach_msg_trap
+1   libsystem_kernel.dylib          0x30a1c909c         mach_msg
+2   CoreFoundation                  0x30c092e90         __CFRunLoopServiceMachPort
+3   CoreFoundation                  0x30c090ae4         __CFRunLoopRun
+4   CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+5   Foundation                      0x30d5f0d74         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+6   Foundation                      0x30d611b44         -[NSRunLoop(NSRunLoop) runUntilDate:]
+7   UIKit                           0x318e536a8         -[UIEventFetcher threadMain]
+8   Foundation                      0x30d6ee2d8         __NSThread__start__
+9   libsystem_pthread.dylib         0x30a39368c         _pthread_body
+10  libsystem_pthread.dylib         0x30a39359c         _pthread_start

--- a/ios/02/_sentry_armv7.crash
+++ b/ios/02/_sentry_armv7.crash
@@ -1,1 +1,14 @@
-<span class="cp-wrong">No report</span>
+OS Version: iOS 9.3.5 (13G36)
+Report Version: 104
+
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+kaboom_exception*
+
+Thread 1 name:
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+0   libsystem_kernel.dylib          0x4504e2f8          kevent_qos
+1   libdispatch.dylib               0x44e38d61          _dispatch_mgr_invoke
+2   libdispatch.dylib               0x44e38abf          _dispatch_mgr_thread$VARIANT$mp

--- a/ios/03/_sentry_arm64.crash
+++ b/ios/03/_sentry_arm64.crash
@@ -1,4 +1,4 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_CRASH (SIGABRT)
@@ -9,28 +9,28 @@ Application threw exception NSGenericException: An uncaught exception! SCREAM.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CoreFoundation                  0x30fdf61b8         ___exceptionPreprocess
-1   libobjc.A.dylib                 0x30d38c55c         _objc_exception_throw
-2   CrashLibiOS                     0x1000ef6d8         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
-3   CrashProbeiOS                   0x2000d82f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-10  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-11  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-12  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-13  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-14  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x31c457130         ___handleEventQueue
-16  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-18  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-19  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-20  GraphicsServices                0x313234198         _GSEventRunModal
-21  UIKit                           0x31bcde7fc         -[UIApplication _run]
-22  UIKit                           0x31bcd9534         _UIApplicationMain
-23  CrashProbeiOS                   0x2000d73cc         main (main.m:16)
-24  libdyld.dylib                   0x30dc9a5b8         _start
+0   CoreFoundation                  0x30c0e4fe0         __exceptionPreprocess
+1   libobjc.A.dylib                 0x3096cc538         objc_exception_throw
+2   CrashLibiOS                     0x100107670         -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0x2000e82bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+10  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+13  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+14  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x318c58770         __handleEventQueue
+16  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+17  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+19  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+20  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+21  GraphicsServices                0x30f490074         GSEventRunModal
+22  UIKit                           0x3184c9058         UIApplicationMain
+23  CrashProbeiOS                   0x2000e7330         main (main.m:16)
+24  libdyld.dylib                   0x309fe259c         start

--- a/ios/03/_sentry_armv7.crash
+++ b/ios/03/_sentry_armv7.crash
@@ -9,25 +9,25 @@ Application threw exception NSGenericException: An uncaught exception! SCREAM.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CoreFoundation                  0x4598d91b          ___exceptionPreprocess
-1   libobjc.A.dylib                 0x449b6e17          _objc_exception_throw
-2   CrashLibiOS                     0x1cb68f            -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
-3   CrashProbeiOS                   0xb7e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-9   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-10  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-11  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-12  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-13  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-14  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-15  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-16  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-17  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-18  GraphicsServices                0x4847dac9          _GSEventRunModal
-19  UIKit                           0x4e5d2189          _UIApplicationMain
-20  CrashProbeiOS                   0xb714f             main (main.m:16)
-21  libdyld.dylib                   0x451f4873          _start
+0   CoreFoundation                  0x4565191b          __exceptionPreprocess
+1   libobjc.A.dylib                 0x4467ae17          objc_exception_throw
+2   CrashLibiOS                     0x1fd66f            -[CRLCrashObjCException crash] (CRLCrashObjCException.m:41)
+3   CrashProbeiOS                   0xe9e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+9   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+11  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+12  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+13  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+15  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+16  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+17  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+18  GraphicsServices                0x48141ac9          GSEventRunModal
+19  UIKit                           0x4e296189          UIApplicationMain
+20  CrashProbeiOS                   0xe90ff             main (main.m:16)
+21  libdyld.dylib                   0x44eb8873          start

--- a/ios/04/_sentry_arm64.crash
+++ b/ios/04/_sentry_arm64.crash
@@ -1,8 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x10
+Exception Codes: BUS_NOOP at 0x0000000000000010
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,36 +10,33 @@ Attempted to dereference garbage pointer 0x10.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30d39ef68         _objc_msgSend
-1   Foundation                      0x311423ba4         __NS_os_log_callback
-2   libsystem_trace.dylib           0x30e087954         __NSCF2data
-3   libsystem_trace.dylib           0x30e087564         __os_log_encode_arg
-4   libsystem_trace.dylib           0x30e087fb8         __os_log_encode
-5   libsystem_trace.dylib           0x30e08b200         _os_log_with_args
-6   libsystem_trace.dylib           0x30e08b49c         _os_log_shim_with_CFString
-7   CoreFoundation                  0x30fdd9de4         __CFLogvEx3
-8   Foundation                      0x311424cb0         __NSLogv
-9   Foundation                      0x31134bb3c         _NSLog
-10  CrashLibiOS                     0x1000c377c         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
-11  CrashProbeiOS                   0x20009c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-12  UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-13  UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-14  UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-15  UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-16  UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-17  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-18  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-19  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-20  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-21  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-22  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-23  UIKit                           0x31c457130         ___handleEventQueue
-24  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-25  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-26  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-27  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-28  GraphicsServices                0x313234198         _GSEventRunModal
-29  UIKit                           0x31bcde7fc         -[UIApplication _run]
-30  UIKit                           0x31bcd9534         _UIApplicationMain
-31  CrashProbeiOS                   0x20009b3cc         main (main.m:16)
-32  libdyld.dylib                   0x30dc9a5b8         _start
+0   libobjc.A.dylib                 0x3096e0148         objc_msgSend
+1   libsystem_trace.dylib           0x30a3c3a34         _os_log_fmt_flatten_data
+2   libsystem_trace.dylib           0x30a3c8ffc         _os_log_impl_flatten_and_send
+3   libsystem_trace.dylib           0x30a3ca934         _os_log_with_args_impl
+4   CoreFoundation                  0x30c0c8960         _CFLogvEx3
+5   Foundation                      0x30d6cf450         _NSLogv
+6   Foundation                      0x30d5f65c8         NSLog
+7   CrashLibiOS                     0x10005b714         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+8   CrashProbeiOS                   0x20002c2bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+9   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+10  UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+11  UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+12  UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+13  UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+14  UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+15  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+16  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+17  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+18  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+19  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+20  UIKit                           0x318c58770         __handleEventQueue
+21  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+22  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+23  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+24  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+25  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+26  GraphicsServices                0x30f490074         GSEventRunModal
+27  UIKit                           0x3184c9058         UIApplicationMain
+28  CrashProbeiOS                   0x20002b330         main (main.m:16)
+29  libdyld.dylib                   0x309fe259c         start

--- a/ios/04/_sentry_armv7.crash
+++ b/ios/04/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x10
+Exception Codes: BUS_NOOP at 0x0000000000000010
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,30 +10,30 @@ Attempted to dereference garbage pointer 0x10.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x449c3a62          _objc_msgSend
-1   Foundation                      0x469fc6e9          __NSDescriptionWithStringProxyFunc
-2   CoreFoundation                  0x4595f6b7          ___CFStringAppendFormatCore
-3   CoreFoundation                  0x4595dc51          __CFStringCreateWithFormatAndArgumentsAux2
-4   CoreFoundation                  0x45976b51          __CFLogvEx2
-5   CoreFoundation                  0x45976fb1          __CFLogvEx3
-6   Foundation                      0x469eb62f          __NSLogv
-7   Foundation                      0x4693203d          _NSLog
-8   CrashLibiOS                     0x2186eb            -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
-9   CrashProbeiOS                   0x104e19            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-10  UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-11  UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-12  UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-13  UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-14  UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-15  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-16  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-17  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-18  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-19  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-20  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-21  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-22  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-23  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-24  GraphicsServices                0x4847dac9          _GSEventRunModal
-25  UIKit                           0x4e5d2189          _UIApplicationMain
-26  CrashProbeiOS                   0x10414f            main (main.m:16)
+0   libobjc.A.dylib                 0x44687a62          objc_msgSend
+1   Foundation                      0x466c06e9          _NSDescriptionWithStringProxyFunc
+2   CoreFoundation                  0x456236b7          __CFStringAppendFormatCore
+3   CoreFoundation                  0x45621c51          _CFStringCreateWithFormatAndArgumentsAux2
+4   CoreFoundation                  0x4563ab51          _CFLogvEx2
+5   CoreFoundation                  0x4563afb1          _CFLogvEx3
+6   Foundation                      0x466af62f          _NSLogv
+7   Foundation                      0x465f603d          NSLog
+8   CrashLibiOS                     0x15b6cb            -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+9   CrashProbeiOS                   0x47e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+10  UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+11  UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+12  UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+13  UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+14  UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+15  UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+16  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+17  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+18  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+19  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+20  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+21  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+22  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+23  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+24  GraphicsServices                0x48141ac9          GSEventRunModal
+25  UIKit                           0x4e296189          UIApplicationMain
+26  CrashProbeiOS                   0x470ff             main (main.m:16)

--- a/ios/05/_sentry_arm64.crash
+++ b/ios/05/_sentry_arm64.crash
@@ -1,8 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x38
+Exception Codes: BUS_NOOP at 0x0000000000000038
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,27 +10,27 @@ Attempted to dereference garbage pointer 0x38.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30d39ef70         _objc_msgSend
-1   CrashLibiOS                     0x1000fb8bc         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
-2   CrashProbeiOS                   0x2000582f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-9   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-12  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-13  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31c457130         ___handleEventQueue
-15  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-17  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-18  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-19  GraphicsServices                0x313234198         _GSEventRunModal
-20  UIKit                           0x31bcde7fc         -[UIApplication _run]
-21  UIKit                           0x31bcd9534         _UIApplicationMain
-22  CrashProbeiOS                   0x2000573cc         main (main.m:16)
-23  libdyld.dylib                   0x30dc9a5b8         _start
+0   libobjc.A.dylib                 0x3096e0150         objc_msgSend
+1   CrashLibiOS                     0x100083854         -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x2000582bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+9   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+12  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+13  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x318c58770         __handleEventQueue
+15  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+16  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+18  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+19  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+20  GraphicsServices                0x30f490074         GSEventRunModal
+21  UIKit                           0x3184c9058         UIApplicationMain
+22  CrashProbeiOS                   0x200057330         main (main.m:16)
+23  libdyld.dylib                   0x309fe259c         start

--- a/ios/05/_sentry_armv7.crash
+++ b/ios/05/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x36
+Exception Codes: BUS_NOOP at 0x0000000000000036
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,23 +10,23 @@ Attempted to dereference garbage pointer 0x36.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x449c3a66          _objc_msgSend
-1   CrashLibiOS                     0x1977f1            -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
-2   CrashProbeiOS                   0x83e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-10  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-11  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-15  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-17  GraphicsServices                0x4847dac9          _GSEventRunModal
-18  UIKit                           0x4e5d2189          _UIApplicationMain
-19  CrashProbeiOS                   0x8314f             main (main.m:16)
+0   libobjc.A.dylib                 0x44687a66          objc_msgSend
+1   CrashLibiOS                     0x1557d1            -[CRLCrashObjCMsgSend crash] (CRLCrashObjCMsgSend.m:47)
+2   CrashProbeiOS                   0x41e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+8   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+10  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+11  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+12  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+14  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+15  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+16  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+17  GraphicsServices                0x48141ac9          GSEventRunModal
+18  UIKit                           0x4e296189          UIApplicationMain
+19  CrashProbeiOS                   0x410ff             main (main.m:16)

--- a/ios/06/_sentry_arm64.crash
+++ b/ios/06/_sentry_arm64.crash
@@ -1,37 +1,37 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa87ffbeb8
+Exception Codes: BUS_NOOP at 0x00000007212bbeb8
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xa87ffbeb8.
+Attempted to dereference garbage pointer 0x7212bbeb8.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30d39ef70         _objc_msgSend
-1   CrashLibiOS                     0x10005ba00         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
-2   CrashLibiOS                     0x10005b9c8         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
-3   CrashProbeiOS                   0x2000442f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-9   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-10  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-11  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-12  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-13  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-14  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-15  UIKit                           0x31c457130         ___handleEventQueue
-16  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-17  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-18  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-19  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-20  GraphicsServices                0x313234198         _GSEventRunModal
-21  UIKit                           0x31bcde7fc         -[UIApplication _run]
-22  UIKit                           0x31bcd9534         _UIApplicationMain
-23  CrashProbeiOS                   0x2000433cc         main (main.m:16)
-24  libdyld.dylib                   0x30dc9a5b8         _start
+0   libobjc.A.dylib                 0x3096e0150         objc_msgSend
+1   CrashLibiOS                     0x10015b998         __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:51)
+2   CrashLibiOS                     0x10015b960         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0x2000bc2bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+10  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+13  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+14  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x318c58770         __handleEventQueue
+16  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+17  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+19  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+20  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+21  GraphicsServices                0x30f490074         GSEventRunModal
+22  UIKit                           0x3184c9058         UIApplicationMain
+23  CrashProbeiOS                   0x2000bb330         main (main.m:16)
+24  libdyld.dylib                   0x309fe259c         start

--- a/ios/06/_sentry_armv7.crash
+++ b/ios/06/_sentry_armv7.crash
@@ -2,32 +2,32 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xe14fed5a
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xe14fed5a.
+Attempted to dereference garbage pointer 0xe15d7dab.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x449c3a66          _objc_msgSend
-1   CrashLibiOS                     0x1d490f            __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
-2   CrashLibiOS                     0x1d48b3            -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
-3   CrashProbeiOS                   0xc0e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-4   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-5   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-6   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-7   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-8   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-9   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-10  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-11  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-12  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-13  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-14  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-15  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-16  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-17  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-18  GraphicsServices                0x4847dac9          _GSEventRunModal
-19  UIKit                           0x4e5d2189          _UIApplicationMain
-20  CrashProbeiOS                   0xc014f             main (main.m:16)
+0   libobjc.A.dylib                 0x44687a66          objc_msgSend
+1   CrashLibiOS                     0x1fa8ef            __31-[CRLCrashReleasedObject crash]_block_invoke (CRLCrashReleasedObject.m:53)
+2   CrashLibiOS                     0x1fa893            -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+3   CrashProbeiOS                   0xe6e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+9   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+11  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+12  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+13  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+15  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+16  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+17  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+18  GraphicsServices                0x48141ac9          GSEventRunModal
+19  UIKit                           0x4e296189          UIApplicationMain
+20  CrashProbeiOS                   0xe60ff             main (main.m:16)

--- a/ios/07/_sentry_arm64.crash
+++ b/ios/07/_sentry_arm64.crash
@@ -1,35 +1,35 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x10007fa40
+Exception Codes: BUS_NOOP at 0x000000010009f9d8
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x10007fa40.
+Attempted to dereference garbage pointer 0x10009f9d8.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10007fad0         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-1   CrashProbeiOS                   0x20005c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x20005b3cc         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x10009fa68         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0x2000742bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x200073330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/07/_sentry_armv7.crash
+++ b/ios/07/_sentry_armv7.crash
@@ -2,30 +2,30 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x1a091b
+Exception Codes: BUS_NOOP at 0x000000000020d8fb
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x1a091b.
+Attempted to dereference garbage pointer 0x20d8fb.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1a0970            -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
-1   CrashProbeiOS                   0x8ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0x8c14f             main (main.m:16)
+0   CrashLibiOS                     0x20d950            -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbeiOS                   0xf9e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+7   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+11  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+13  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+14  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+15  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+16  GraphicsServices                0x48141ac9          GSEventRunModal
+17  UIKit                           0x4e296189          UIApplicationMain
+18  CrashProbeiOS                   0xf90ff             main (main.m:16)

--- a/ios/08/_sentry_arm64.crash
+++ b/ios/08/_sentry_arm64.crash
@@ -1,8 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x100063b5c
+Exception Codes: ILL_NOOP at 0x000000010003faf4
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,26 +10,26 @@ Exception 2, Code 3574368159, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100063b5c         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
-1   CrashProbeiOS                   0x20004c2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x20004b3cc         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x10003faf4         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:52)
+1   CrashProbeiOS                   0x2000282bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x200027330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/08/_sentry_armv7.crash
+++ b/ios/08/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x20d9be
+Exception Codes: ILL_NOOP at 0x000000000022299e
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,22 +10,22 @@ Exception 2, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x20d9be            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
-1   CrashProbeiOS                   0xf9e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0xf914f             main (main.m:16)
+0   CrashLibiOS                     0x22299e            -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:42)
+1   CrashProbeiOS                   0x10ee03            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+7   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+11  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+13  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+14  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+15  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+16  GraphicsServices                0x48141ac9          GSEventRunModal
+17  UIKit                           0x4e296189          UIApplicationMain
+18  CrashProbeiOS                   0x10e0ff            main (main.m:16)

--- a/ios/09/_sentry_arm64.crash
+++ b/ios/09/_sentry_arm64.crash
@@ -1,8 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x1000b7be8
+Exception Codes: ILL_NOOP at 0x0000000100107b80
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,26 +10,26 @@ Exception 2, Code 4160266240, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000b7be8         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
-1   CrashProbeiOS                   0x2000842f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000833cc         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x100107b80         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:50)
+1   CrashProbeiOS                   0x2000e42bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x2000e3330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/09/_sentry_armv7.crash
+++ b/ios/09/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
-Exception Codes: ILL_NOOP at 0x212a0a
+Exception Codes: ILL_NOOP at 0x00000000001ed9ea
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,22 +10,22 @@ Exception 2, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x212a0a            -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
-1   CrashProbeiOS                   0xfee19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0xfe14f             main (main.m:16)
+0   CrashLibiOS                     0x1ed9ea            -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:42)
+1   CrashProbeiOS                   0xd9e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+7   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+11  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+13  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+14  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+15  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+16  GraphicsServices                0x48141ac9          GSEventRunModal
+17  UIKit                           0x4e296189          UIApplicationMain
+18  CrashProbeiOS                   0xd90ff             main (main.m:16)

--- a/ios/10/_sentry_arm64.crash
+++ b/ios/10/_sentry_arm64.crash
@@ -1,7 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -9,26 +10,26 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x100053c78         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-1   CrashProbeiOS                   0x2000242f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000233cc         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x1000dfc10         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x2000c42bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x2000c3330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/10/_sentry_armv7.crash
+++ b/ios/10/_sentry_armv7.crash
@@ -2,6 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Exception Codes: SEGV_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -9,22 +10,22 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x132a5a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
-1   CrashProbeiOS                   0x1ee19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0x1e14f             main (main.m:16)
+0   CrashLibiOS                     0x14ea3a            -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbeiOS                   0x3ae03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+7   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+11  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+13  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+14  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+15  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+16  GraphicsServices                0x48141ac9          GSEventRunModal
+17  UIKit                           0x4e296189          UIApplicationMain
+18  CrashProbeiOS                   0x3a0ff             main (main.m:16)

--- a/ios/11/_sentry_arm64.crash
+++ b/ios/11/_sentry_arm64.crash
@@ -1,35 +1,35 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x104650000
+Exception Codes: BUS_NOOP at 0x0000000102664000
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x104650000.
+Attempted to dereference garbage pointer 0x102664000.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000afd50         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
-1   CrashProbeiOS                   0x2000802f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x20007f3cc         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x100103ce8         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:52)
+1   CrashProbeiOS                   0x2000502bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x20004f330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/11/_sentry_armv7.crash
+++ b/ios/11/_sentry_armv7.crash
@@ -2,31 +2,31 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x3425000
+Exception Codes: BUS_NOOP at 0x00000000024a4000
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0x3425000.
+Attempted to dereference garbage pointer 0x24a4000.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1e8ade            -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
-1   libsystem_kernel.dylib          0x4537541f          _munmap
-2   CrashProbeiOS                   0xd4e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-10  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-11  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-15  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-17  GraphicsServices                0x4847dac9          _GSEventRunModal
-18  UIKit                           0x4e5d2189          _UIApplicationMain
-19  CrashProbeiOS                   0xd414f             main (main.m:16)
+0   CrashLibiOS                     0x146abe            -[CRLCrashGarbage crash] (CRLCrashGarbage.m:48)
+1   libsystem_kernel.dylib          0x4503941f          munmap
+2   CrashProbeiOS                   0x32e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+8   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+10  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+11  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+12  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+14  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+15  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+16  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+17  GraphicsServices                0x48141ac9          GSEventRunModal
+18  UIKit                           0x4e296189          UIApplicationMain
+19  CrashProbeiOS                   0x320ff             main (main.m:16)

--- a/ios/12/_sentry_arm64.crash
+++ b/ios/12/_sentry_arm64.crash
@@ -1,34 +1,37 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
-Exception Type: EXC_BREAKPOINT
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x0000000104960000
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 359864, Subcode 8
+Attempted to dereference garbage pointer 0x104960000.
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x100057db8         -[CRLCrashNXPage crash] | Missing line number</span>
-1   CrashProbeiOS                   0x200038220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000372a4         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   <unknown>                       0x104960000         <redacted>
+1   CrashLibiOS                     0x100103dd0         real_NXcrash (CRLCrashNXPage.m:41)
+2   CrashLibiOS                     0x100103d88         -[CRLCrashNXPage crash] (CRLCrashNXPage.m:49)
+3   CrashProbeiOS                   0x2000ec2bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+9   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+10  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+11  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+12  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+13  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+14  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+15  UIKit                           0x318c58770         __handleEventQueue
+16  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+17  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+18  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+19  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+20  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+21  GraphicsServices                0x30f490074         GSEventRunModal
+22  UIKit                           0x3184c9058         UIApplicationMain
+23  CrashProbeiOS                   0x2000eb330         main (main.m:16)
+24  libdyld.dylib                   0x309fe259c         start

--- a/ios/12/_sentry_armv7.crash
+++ b/ios/12/_sentry_armv7.crash
@@ -1,30 +1,33 @@
 OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
-Exception Type: EXC_BREAKPOINT
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x0000000000adf000
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 1, Subcode 0
+Attempted to dereference garbage pointer 0xadf000.
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x1b0b2c            -[CRLCrashNXPage crash] | Missing line number</span>
-1   CrashProbeiOS                   0x9ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0x9c14f             main (main.m:16)
+0   <unknown>                       0xadf000            <redacted>
+1   CrashLibiOS                     0x190b47            real_NXcrash (CRLCrashNXPage.m:41)
+2   CrashLibiOS                     0x190b15            -[CRLCrashNXPage crash] (CRLCrashNXPage.m:49)
+3   CrashProbeiOS                   0x7ce03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+4   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+5   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+6   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+7   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+8   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+9   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+10  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+11  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+12  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+13  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+14  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+15  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+16  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+17  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+18  GraphicsServices                0x48141ac9          GSEventRunModal
+19  UIKit                           0x4e296189          UIApplicationMain
+20  CrashProbeiOS                   0x7c0ff             main (main.m:16)

--- a/ios/12/data.json
+++ b/ios/12/data.json
@@ -33,7 +33,7 @@
       "arm64": "incomplete"
     },
     "Sentry": {
-      "armv7": "incomplete",
+      "armv7": "complete",
       "arm64": "complete"
     }
   }

--- a/ios/12/data.json
+++ b/ios/12/data.json
@@ -34,7 +34,7 @@
     },
     "Sentry": {
       "armv7": "incomplete",
-      "arm64": "incomplete"
+      "arm64": "complete"
     }
   }
 }

--- a/ios/13/_sentry_arm64.crash
+++ b/ios/13/_sentry_arm64.crash
@@ -1,8 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x16fc57ff0
+Exception Codes: BUS_NOOP at 0x000000016fcfbff0
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,8 +10,8 @@ Stack overflow in (null)
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000cbe6c         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
-1   CrashLibiOS                     0x1000cbe80         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
-2   CrashLibiOS                     0x1000cbe80         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+0   CrashLibiOS                     0x100027e6c         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
+1   CrashLibiOS                     0x100027e80         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLibiOS                     0x100027e80         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
 ...
-99  CrashLibiOS                     0x1000cbe80         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+99  CrashLibiOS                     0x100027e80         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/ios/13/_sentry_armv7.crash
+++ b/ios/13/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0x1eeffc
+Exception Codes: BUS_NOOP at 0x0000000000031ff8
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,8 +10,8 @@ Stack overflow in (null)
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1c4b76            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
-1   CrashLibiOS                     0x1c4b8b            [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
-2   CrashLibiOS                     0x1c4b8b            [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+0   CrashLibiOS                     0x135b9a            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:38)
+1   CrashLibiOS                     0x135baf            [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLibiOS                     0x135baf            [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
 ...
-99  CrashLibiOS                     0x1c4b8b            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+99  CrashLibiOS                     0x135baf            -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/ios/14/_sentry_arm64.crash
+++ b/ios/14/_sentry_arm64.crash
@@ -1,34 +1,34 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 1048344, Subcode 8
+Exception 6, Code 1015576, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1000fff18         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
-1   CrashProbeiOS                   0x2000cc2f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000cb3cc         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x1000f7f18         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x2000dc2bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x2000db330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/14/_sentry_armv7.crash
+++ b/ios/14/_sentry_armv7.crash
@@ -9,22 +9,22 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x141be2            -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
-1   CrashProbeiOS                   0x2de19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0x2d14f             main (main.m:16)
+0   CrashLibiOS                     0x196c06            -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbeiOS                   0x82e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+7   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+11  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+13  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+14  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+15  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+16  GraphicsServices                0x48141ac9          GSEventRunModal
+17  UIKit                           0x4e296189          UIApplicationMain
+18  CrashProbeiOS                   0x820ff             main (main.m:16)

--- a/ios/15/_sentry_arm64.crash
+++ b/ios/15/_sentry_arm64.crash
@@ -1,4 +1,4 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_CRASH (SIGABRT)
@@ -9,29 +9,29 @@ Signal 6, Code 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x30dea3014         ___pthread_kill
-1   libsystem_pthread.dylib         0x30e04d450         _pthread_kill
-2   libsystem_c.dylib               0x30dd47400         _abort
-3   CrashLibiOS                     0x10006bfac         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
-4   CrashProbeiOS                   0x2000502f8         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-11  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-14  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-15  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31c457130         ___handleEventQueue
-17  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-19  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-20  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-21  GraphicsServices                0x313234198         _GSEventRunModal
-22  UIKit                           0x31bcde7fc         -[UIApplication _run]
-23  UIKit                           0x31bcd9534         _UIApplicationMain
-24  CrashProbeiOS                   0x20004f3cc         main (main.m:16)
-25  libdyld.dylib                   0x30dc9a5b8         _start
+0   libsystem_kernel.dylib          0x30a1e7014         __pthread_kill
+1   libsystem_pthread.dylib         0x30a395264         pthread_kill
+2   libsystem_c.dylib               0x30a08d9c4         abort
+3   CrashLibiOS                     0x10010ffac         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x2000f82bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+11  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+14  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+15  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x318c58770         __handleEventQueue
+17  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+18  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+19  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+20  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+21  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+22  GraphicsServices                0x30f490074         GSEventRunModal
+23  UIKit                           0x3184c9058         UIApplicationMain
+24  CrashProbeiOS                   0x2000f7330         main (main.m:16)
+25  libdyld.dylib                   0x309fe259c         start

--- a/ios/15/_sentry_armv7.crash
+++ b/ios/15/_sentry_armv7.crash
@@ -9,25 +9,25 @@ Signal 6, Code 0
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x45388c5c          ___pthread_kill
-1   libsystem_pthread.dylib         0x454ec733          _pthread_kill
-2   libsystem_c.dylib               0x4527b0ad          _abort
-3   CrashLibiOS                     0x1d3c35            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
-4   CrashProbeiOS                   0xbfe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-10  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-11  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-12  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-13  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-14  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-16  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-17  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-18  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-19  GraphicsServices                0x4847dac9          _GSEventRunModal
-20  UIKit                           0x4e5d2189          _UIApplicationMain
-21  CrashProbeiOS                   0xbf14f             main (main.m:16)
+0   libsystem_kernel.dylib          0x4504cc5c          __pthread_kill
+1   libsystem_pthread.dylib         0x451b0733          pthread_kill
+2   libsystem_c.dylib               0x44f3f0ad          abort
+3   CrashLibiOS                     0x143c59            -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+4   CrashProbeiOS                   0x2fe03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+10  UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+11  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+12  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+13  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+14  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+15  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+16  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+17  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+18  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+19  GraphicsServices                0x48141ac9          GSEventRunModal
+20  UIKit                           0x4e296189          UIApplicationMain
+21  CrashProbeiOS                   0x2f0ff             main (main.m:16)

--- a/ios/16/_sentry_arm64.crash
+++ b/ios/16/_sentry_arm64.crash
@@ -1,43 +1,43 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xabababababababab
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xabababababababab.
+Attempted to dereference garbage pointer 0xababababababac8b.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30d38a698         _object_setClass
-1   CoreFoundation                  0x30fcc9540         [inlined] __CFRuntimeCreateInstance
-2   CoreFoundation                  0x30fcc9540         __CFRuntimeCreateInstance
-3   CoreFoundation                  0x30fdb5234         __CFStringCreateWithFormatAndArgumentsAux2
-4   CoreFoundation                  0x30fdd9b90         __CFLogvEx2Predicate
-5   CoreFoundation                  0x30fdd9ee4         __CFLogvEx3
-6   Foundation                      0x311424cb0         __NSLogv
-7   Foundation                      0x31134bb3c         _NSLog
-8   CrashLibiOS                     0x1000f4048         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
-9   CrashProbeiOS                   0x2000c4220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-10  UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-11  UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-12  UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-13  UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-14  UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-15  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-16  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-17  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-18  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-19  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-20  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-21  UIKit                           0x31c457130         ___handleEventQueue
-22  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-23  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-24  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-25  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-26  GraphicsServices                0x313234198         _GSEventRunModal
-27  UIKit                           0x31bcde7fc         -[UIApplication _run]
-28  UIKit                           0x31bcd9534         _UIApplicationMain
-29  CrashProbeiOS                   0x2000c32a4         main (main.m:16)
-30  libdyld.dylib                   0x30dc9a5b8         _start
+0   libsystem_notify.dylib          0x30a37616c         _nc_table_find_64
+1   libsystem_notify.dylib          0x30a3732fc         registration_node_find
+2   libsystem_notify.dylib          0x30a374700         notify_check
+3   libsystem_c.dylib               0x30a031734         notify_check_tz
+4   libsystem_c.dylib               0x30a0315a0         tzsetwall_basic
+5   libsystem_c.dylib               0x30a031214         localtime_r
+6   CoreFoundation                  0x30c0ca538         _populateBanner
+7   CoreFoundation                  0x30c0c87e0         _CFLogvEx2Predicate
+8   CoreFoundation                  0x30c0c8a80         _CFLogvEx3
+9   Foundation                      0x30d6cf450         _NSLogv
+10  Foundation                      0x30d5f65c8         NSLog
+11  CrashLibiOS                     0x10007c074         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+12  CrashProbeiOS                   0x2000602bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+13  UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+14  UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+15  UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+16  UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+17  UIKit                           0x318498390         -[UIWindow _sendTouchesForEvent:]
+18  UIKit                           0x318493728         -[UIWindow sendEvent:]
+19  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+20  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+21  UIKit                           0x318c58770         __handleEventQueue
+22  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+23  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+24  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+25  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+26  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+27  GraphicsServices                0x30f490074         GSEventRunModal
+28  UIKit                           0x3184c9058         UIApplicationMain
+29  CrashProbeiOS                   0x20005f330         main (main.m:16)
+30  libdyld.dylib                   0x309fe259c         start

--- a/ios/16/_sentry_armv7.crash
+++ b/ios/16/_sentry_armv7.crash
@@ -9,37 +9,39 @@ Rogue memory write has corrupted memory.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libsystem_kernel.dylib          0x45388c5c          ___pthread_kill
-1   libsystem_pthread.dylib         0x454ec733          _pthread_kill
-2   libsystem_c.dylib               0x4527b0ad          _abort
-3   libsystem_malloc.dylib          0x453f60ad          _szone_error
-4   libsystem_malloc.dylib          0x453f60c9          _free_list_checksum_botch
-5   libsystem_malloc.dylib          0x453edf8b          _tiny_malloc_from_free_list
-6   libsystem_malloc.dylib          0x453eca0f          _szone_malloc_should_clear
-7   libsystem_malloc.dylib          0x453eff5f          _malloc_zone_calloc
-8   libsystem_malloc.dylib          0x453efeef          _calloc
-9   CoreFoundation                  0x4595f1bf          ___CFStringAppendFormatCore
-10  CoreFoundation                  0x4595dc51          __CFStringCreateWithFormatAndArgumentsAux2
-11  CoreFoundation                  0x45976b51          __CFLogvEx2
-12  CoreFoundation                  0x45976fb1          __CFLogvEx3
-13  Foundation                      0x469eb62f          __NSLogv
-14  Foundation                      0x4693203d          _NSLog
-15  CrashLibiOS                     0x15bcab            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
-16  CrashProbeiOS                   0x47e19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-17  UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-18  UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-19  UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-20  UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-21  UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-22  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-23  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-24  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-25  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-26  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-27  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-28  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-29  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-30  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-31  GraphicsServices                0x4847dac9          _GSEventRunModal
-32  UIKit                           0x4e5d2189          _UIApplicationMain
-33  CrashProbeiOS                   0x4714f             main (main.m:16)
+0   libsystem_kernel.dylib          0x4504cc5c          __pthread_kill
+1   libsystem_pthread.dylib         0x451b0733          pthread_kill
+2   libsystem_c.dylib               0x44f3f0ad          abort
+3   libsystem_malloc.dylib          0x450ba0ad          szone_error
+4   libsystem_malloc.dylib          0x450ba0c9          free_list_checksum_botch
+5   libsystem_malloc.dylib          0x450b1f8b          tiny_malloc_from_free_list
+6   libsystem_malloc.dylib          0x450b0a0f          szone_malloc_should_clear
+7   libsystem_malloc.dylib          0x450b08fb          malloc_zone_malloc
+8   libsystem_malloc.dylib          0x450b3feb          malloc
+9   libsystem_c.dylib               0x44ef6c8b          _vasprintf
+10  libsystem_c.dylib               0x44ef6ba5          vasprintf_l
+11  libsystem_c.dylib               0x44ef6b79          asprintf
+12  CoreFoundation                  0x4563ad5b          __CFLogCString
+13  CoreFoundation                  0x4563abc5          _CFLogvEx2
+14  CoreFoundation                  0x4563afb1          _CFLogvEx3
+15  Foundation                      0x466af62f          _NSLogv
+16  Foundation                      0x465f603d          NSLog
+17  CrashLibiOS                     0x215ccf            -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+18  CrashProbeiOS                   0x101e03            -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+19  UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+20  UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+21  UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+22  UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+23  UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+24  UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+25  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+26  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+27  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+28  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+29  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+30  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+31  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+32  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+33  GraphicsServices                0x48141ac9          GSEventRunModal
+34  UIKit                           0x4e296189          UIApplicationMain
+35  CrashProbeiOS                   0x1010ff            main (main.m:16)

--- a/ios/17/_sentry_arm64.crash
+++ b/ios/17/_sentry_arm64.crash
@@ -1,38 +1,38 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a5adf7adaff5
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xa5a5a5adf7adaff5.
+Attempted to dereference garbage pointer 0xa5a5a5adbdbfbdb5.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x30d39f370         _cache_getImp
-1   libobjc.A.dylib                 0x30d394cb4         _lookUpImpOrForward
-2   libobjc.A.dylib                 0x30d39f298         __objc_msgSend_uncached
-3   CrashLibiOS                     0x100040138         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
-4   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-5   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-6   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-7   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-8   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-9   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-10  UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-11  UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-12  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-13  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-14  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-15  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-16  UIKit                           0x31c457130         ___handleEventQueue
-17  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-18  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-19  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-20  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-21  GraphicsServices                0x313234198         _GSEventRunModal
-22  UIKit                           0x31bcde7fc         -[UIApplication _run]
-23  UIKit                           0x31bcd9534         _UIApplicationMain
-24  CrashProbeiOS                   0x20000f2a4         main (main.m:16)
-25  libdyld.dylib                   0x30dc9a5b8         _start
+0   libobjc.A.dylib                 0x3096e0550         cache_getImp
+1   libobjc.A.dylib                 0x3096d552c         lookUpImpOrForward
+2   libobjc.A.dylib                 0x3096e0478         _objc_msgSend_uncached
+3   CrashLibiOS                     0x1000b0164         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+4   CrashProbeiOS                   0x2000902bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+5   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+6   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+7   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+8   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+9   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+10  UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+11  UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+12  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+13  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+14  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+15  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+16  UIKit                           0x318c58770         __handleEventQueue
+17  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+18  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+19  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+20  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+21  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+22  GraphicsServices                0x30f490074         GSEventRunModal
+23  UIKit                           0x3184c9058         UIApplicationMain
+24  CrashProbeiOS                   0x20008f330         main (main.m:16)
+25  libdyld.dylib                   0x309fe259c         start

--- a/ios/17/_sentry_armv7.crash
+++ b/ios/17/_sentry_armv7.crash
@@ -2,34 +2,34 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a9c5
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
-Attempted to dereference garbage pointer 0xa5a5a9c5.
+Attempted to dereference garbage pointer 0xa5a9a9c5.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   libobjc.A.dylib                 0x449c3a12          _cache_getImp
-1   libobjc.A.dylib                 0x449bd9d1          _lookUpImpOrForward
-2   libobjc.A.dylib                 0x449bd873          __class_lookupMethodAndLoadCache3
-3   libobjc.A.dylib                 0x449c3cfb          __objc_msgSend_uncached
-4   CrashLibiOS                     0x173d43            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
-5   CrashProbeiOS                   0x5fe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-6   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-7   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-8   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-9   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-10  UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-11  UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-12  UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-13  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-14  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-15  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-17  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-18  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-19  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-20  GraphicsServices                0x4847dac9          _GSEventRunModal
-21  UIKit                           0x4e5d2189          _UIApplicationMain
-22  CrashProbeiOS                   0x5f14f             main (main.m:16)
+0   libobjc.A.dylib                 0x44687a12          cache_getImp
+1   libobjc.A.dylib                 0x446819d1          lookUpImpOrForward
+2   libobjc.A.dylib                 0x44681873          _class_lookupMethodAndLoadCache3
+3   libobjc.A.dylib                 0x44687cfb          _objc_msgSend_uncached
+4   CrashLibiOS                     0x12dd67            -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+5   CrashProbeiOS                   0x19e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+6   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+7   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+8   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+9   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+10  UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+11  UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+12  UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+13  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+14  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+15  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+17  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+18  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+19  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+20  GraphicsServices                0x48141ac9          GSEventRunModal
+21  UIKit                           0x4e296189          UIApplicationMain
+22  CrashProbeiOS                   0x190ff             main (main.m:16)

--- a/ios/18/_sentry_arm64.crash
+++ b/ios/18/_sentry_arm64.crash
@@ -1,7 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -9,6 +10,6 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10008c158         CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
-1   CrashLibiOS                     0x10008c210         CRLFramelessDWARF_test
+0   CrashLibiOS                     0x1000f8184         CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                     0x1000f823c         CRLFramelessDWARF_test
 <span class="cp-wrong">Missing frames</span>

--- a/ios/18/_sentry_armv7.crash
+++ b/ios/18/_sentry_armv7.crash
@@ -2,6 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Exception Codes: SEGV_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -9,6 +10,6 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x123d52            CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
-1   CrashLibiOS                     0x123dc0            CRLFramelessDWARF_test
+0   CrashLibiOS                     0x19ed76            CRLFramelessDWARF_test_crash (CRLFramelessDWARF.m:35)
+1   CrashLibiOS                     0x19ede4            CRLFramelessDWARF_test
 <span class="cp-wrong">Missing frames</span>

--- a/ios/19/_sentry_arm64.crash
+++ b/ios/19/_sentry_arm64.crash
@@ -1,7 +1,8 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -9,26 +10,26 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x10011c2dc         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-1   CrashProbeiOS                   0x2000f8220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-7   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-8   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-9   UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-10  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-11  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-12  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-13  UIKit                           0x31c457130         ___handleEventQueue
-14  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-15  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-16  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-17  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-18  GraphicsServices                0x313234198         _GSEventRunModal
-19  UIKit                           0x31bcde7fc         -[UIApplication _run]
-20  UIKit                           0x31bcd9534         _UIApplicationMain
-21  CrashProbeiOS                   0x2000f72a4         main (main.m:16)
-22  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x100038308         -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashProbeiOS                   0x20000c2bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+7   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+8   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+9   UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+10  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+11  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+12  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+13  UIKit                           0x318c58770         __handleEventQueue
+14  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+15  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+16  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+17  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+18  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+19  GraphicsServices                0x30f490074         GSEventRunModal
+20  UIKit                           0x3184c9058         UIApplicationMain
+21  CrashProbeiOS                   0x20000b330         main (main.m:16)
+22  libdyld.dylib                   0x309fe259c         start

--- a/ios/19/_sentry_armv7.crash
+++ b/ios/19/_sentry_armv7.crash
@@ -2,6 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Exception Codes: SEGV_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -9,22 +10,22 @@ Attempted to dereference null pointer.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x1bfe52            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
-1   CrashProbeiOS                   0xabe19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-2   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-3   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-4   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-5   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-6   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-7   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-8   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-9   UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-10  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-11  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-12  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-13  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-14  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-15  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-16  GraphicsServices                0x4847dac9          _GSEventRunModal
-17  UIKit                           0x4e5d2189          _UIApplicationMain
-18  CrashProbeiOS                   0xab14f             main (main.m:16)
+0   CrashLibiOS                     0x1d2e76            -[CRLCrashOverwriteLinkRegister crash] (CRLCrashOverwriteLinkRegister.m:53)
+1   CrashProbeiOS                   0xbee03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+2   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+3   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+4   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+5   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+6   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+7   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+8   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+9   UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+10  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+11  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+12  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+13  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+14  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+15  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+16  GraphicsServices                0x48141ac9          GSEventRunModal
+17  UIKit                           0x4e296189          UIApplicationMain
+18  CrashProbeiOS                   0xbe0ff             main (main.m:16)

--- a/ios/20/_sentry_arm64.crash
+++ b/ios/20/_sentry_arm64.crash
@@ -1,27 +1,27 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a5a5a5a5a5a5
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
 Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
 
-<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
-Thread 1 name:
-0   libsystem_kernel.dylib          0x30dea3a88         ___workq_kernreturn
-1   libsystem_pthread.dylib         0x30e049160         __pthread_wqthread
+Thread 0 name:
+Thread 0 Crashed:
+0   <unknown>                       0xa5a5a5a5a5a5a5a5L <redacted>
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
 
-Thread 2 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x30de85188         _mach_msg_trap
-1   libsystem_kernel.dylib          0x30de84ff8         _mach_msg
-2   CoreFoundation                  0x30fda35d0         ___CFRunLoopServiceMachPort
-3   CoreFoundation                  0x30fda11ec         ___CFRunLoopRun
-4   CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-5   Foundation                      0x31134626c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
-6   Foundation                      0x311366dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
-7   UIKit                           0x31c652c38         -[UIEventFetcher threadMain]
-8   Foundation                      0x311443e68         ___NSThread__start__
-9   libsystem_pthread.dylib         0x30e04b850         __pthread_body
-10  libsystem_pthread.dylib         0x30e04b760         __pthread_start
+Thread 1 name: com.apple.uikit.eventfetch-thread
+0   libsystem_kernel.dylib          0x30a1c9224         mach_msg_trap
+1   libsystem_kernel.dylib          0x30a1c909c         mach_msg
+2   CoreFoundation                  0x30c092e90         __CFRunLoopServiceMachPort
+3   CoreFoundation                  0x30c090ae4         __CFRunLoopRun
+4   CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+5   Foundation                      0x30d5f0d74         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
+6   Foundation                      0x30d611b44         -[NSRunLoop(NSRunLoop) runUntilDate:]
+7   UIKit                           0x318e536a8         -[UIEventFetcher threadMain]
+8   Foundation                      0x30d6ee2d8         __NSThread__start__
+9   libsystem_pthread.dylib         0x30a39368c         _pthread_body
+10  libsystem_pthread.dylib         0x30a39359c         _pthread_start

--- a/ios/20/_sentry_armv7.crash
+++ b/ios/20/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a5a4
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,9 +10,10 @@ Attempted to dereference garbage pointer 0xa5a5a5a4.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x141eb7            -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:54)
+0   <unknown>                       0xa5a5a5a4          <redacted>
+1   CrashLibiOS                     0x151edb            -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:54)
 
 Thread 1 name:
-0   libsystem_kernel.dylib          0x4538a2f8          _kevent_qos
-1   libdispatch.dylib               0x45174d61          __dispatch_mgr_invoke
-2   libdispatch.dylib               0x45174abf          __dispatch_mgr_thread$VARIANT$mp
+0   libsystem_kernel.dylib          0x4504e2f8          kevent_qos
+1   libdispatch.dylib               0x44e38d61          _dispatch_mgr_invoke
+2   libdispatch.dylib               0x44e38abf          _dispatch_mgr_thread$VARIANT$mp

--- a/ios/21/_sentry_arm64.crash
+++ b/ios/21/_sentry_arm64.crash
@@ -1,27 +1,22 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a5a5a5a5a5a5
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
 Attempted to dereference garbage pointer 0xa5a5a5a5a5a5a5a5.
 
-<span class="cp-wrong">Missing frame/thread that shows where the crash occured</span>
-Thread 1 name:
-0   libsystem_kernel.dylib          0x30dea3a88         ___workq_kernreturn
-1   libsystem_pthread.dylib         0x30e049160         __pthread_wqthread
+Thread 0 name:
+Thread 0 Crashed:
+0   <unknown>                       0xa5a5a5a5a5a5a5a5L <redacted>
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
 
-Thread 2 name: com.apple.uikit.eventfetch-thread
-0   libsystem_kernel.dylib          0x30de85188         _mach_msg_trap
-1   libsystem_kernel.dylib          0x30de84ff8         _mach_msg
-2   CoreFoundation                  0x30fda35d0         ___CFRunLoopServiceMachPort
-3   CoreFoundation                  0x30fda11ec         ___CFRunLoopRun
-4   CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-5   Foundation                      0x31134626c         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
-6   Foundation                      0x311366dd0         -[NSRunLoop(NSRunLoop) runUntilDate:]
-7   UIKit                           0x31c652c38         -[UIEventFetcher threadMain]
-8   Foundation                      0x311443e68         ___NSThread__start__
-9   libsystem_pthread.dylib         0x30e04b850         __pthread_body
-10  libsystem_pthread.dylib         0x30e04b760         __pthread_start
+Thread 1 name:
+0   libsystem_kernel.dylib          0x30a1e7a88         __workq_kernreturn
+1   libsystem_pthread.dylib         0x30a390fd0         _pthread_wqthread
+
+Thread 2 name:
+0   libsystem_kernel.dylib          0x30a1e7a88         __workq_kernreturn
+1   libsystem_pthread.dylib         0x30a390fd0         _pthread_wqthread

--- a/ios/21/_sentry_armv7.crash
+++ b/ios/21/_sentry_armv7.crash
@@ -2,7 +2,7 @@ OS Version: iOS 9.3.5 (13G36)
 Report Version: 104
 
 Exception Type: EXC_BAD_ACCESS (SIGBUS)
-Exception Codes: BUS_NOOP at 0xa5a5a5a4
+Exception Codes: BUS_NOOP
 Crashed Thread: 0
 
 Application Specific Information:
@@ -10,9 +10,10 @@ Attempted to dereference garbage pointer 0xa5a5a5a4.
 
 Thread 0 name:
 Thread 0 Crashed:
-0   CrashLibiOS                     0x212f1f            -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:54)
+0   <unknown>                       0xa5a5a5a4          <redacted>
+1   CrashLibiOS                     0x159f43            -[CRLCrashSmashStackTop crash] (CRLCrashSmashStackTop.m:54)
 
 Thread 1 name:
-0   libsystem_kernel.dylib          0x4538a2f8          _kevent_qos
-1   libdispatch.dylib               0x45174d61          __dispatch_mgr_invoke
-2   libdispatch.dylib               0x45174abf          __dispatch_mgr_thread$VARIANT$mp
+0   libsystem_kernel.dylib          0x4504e2f8          kevent_qos
+1   libdispatch.dylib               0x44e38d61          _dispatch_mgr_invoke
+2   libdispatch.dylib               0x44e38abf          _dispatch_mgr_thread$VARIANT$mp

--- a/ios/22/_sentry_arm64.crash
+++ b/ios/22/_sentry_arm64.crash
@@ -1,35 +1,35 @@
-OS Version: iOS 10.2.1 (14D27)
+OS Version: iOS 10.3.2 (14F89)
 Report Version: 104
 
 Exception Type: EXC_BREAKPOINT
 Crashed Thread: 0
 
 Application Specific Information:
-Exception 6, Code 214272, Subcode 8
+Exception 6, Code 132396, Subcode 8
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x100034500         [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)</span>
-<span class="cp-wrong">1   CrashLibiOS                     0x100034500         @objc CRLCrashSwift.crash() -> ()</span>
-2   CrashProbeiOS                   0x200010220         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x31bca8d30         -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x31bca8cb0         -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x31bc93128         -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x31bca859c         -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x31c233628         __UIGestureEnvironmentSortAndSendDelayedTouches
-8   UIKit                           0x31c22f6c0         __UIGestureEnvironmentUpdate
-9   UIKit                           0x31c22f1e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
-10  UIKit                           0x31c22e49c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
-11  UIKit                           0x31bca330c         -[UIWindow sendEvent:]
-12  UIKit                           0x31bc73da0         -[UIApplication sendEvent:]
-13  UIKit                           0x31c45d75c         ___dispatchPreprocessedEventFromEventQueue
-14  UIKit                           0x31c457130         ___handleEventQueue
-15  CoreFoundation                  0x30fda3b5c         ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-16  CoreFoundation                  0x30fda34a4         ___CFRunLoopDoSources0
-17  CoreFoundation                  0x30fda10a4         ___CFRunLoopRun
-18  CoreFoundation                  0x30fccf2b8         _CFRunLoopRunSpecific
-19  GraphicsServices                0x313234198         _GSEventRunModal
-20  UIKit                           0x31bcde7fc         -[UIApplication _run]
-21  UIKit                           0x31bcd9534         _UIApplicationMain
-22  CrashProbeiOS                   0x20000f2a4         main (main.m:16)
-23  libdyld.dylib                   0x30dc9a5b8         _start
+0   CrashLibiOS                     0x10002052c         [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+1   CrashLibiOS                     0x10002052c         @objc CRLCrashSwift.crash() -> ()
+2   CrashProbeiOS                   0x2000082bc         -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x318499010         -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x318498f90         -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x318483504         -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x318498874         -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x318a2d550         _UIGestureEnvironmentSortAndSendDelayedTouches
+8   UIKit                           0x318a2989c         _UIGestureEnvironmentUpdate
+9   UIKit                           0x318a293e0         -[UIGestureEnvironment _deliverEvent:toGestureRecognizers:usingBlock:]
+10  UIKit                           0x318a2868c         -[UIGestureEnvironment _updateGesturesForEvent:window:]
+11  UIKit                           0x31849370c         -[UIWindow sendEvent:]
+12  UIKit                           0x31846433c         -[UIApplication sendEvent:]
+13  UIKit                           0x318c5e014         __dispatchPreprocessedEventFromEventQueue
+14  UIKit                           0x318c58770         __handleEventQueue
+15  UIKit                           0x318c58b9c         __handleHIDEventFetcherDrain
+16  CoreFoundation                  0x30c09342c         __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+17  CoreFoundation                  0x30c092d9c         __CFRunLoopDoSources0
+18  CoreFoundation                  0x30c0909a8         __CFRunLoopRun
+19  CoreFoundation                  0x30bfc0da4         CFRunLoopRunSpecific
+20  GraphicsServices                0x30f490074         GSEventRunModal
+21  UIKit                           0x3184c9058         UIApplicationMain
+22  CrashProbeiOS                   0x200007330         main (main.m:16)
+23  libdyld.dylib                   0x309fe259c         start

--- a/ios/22/_sentry_armv7.crash
+++ b/ios/22/_sentry_armv7.crash
@@ -9,23 +9,23 @@ Exception 6, Code 1, Subcode 0
 
 Thread 0 name:
 Thread 0 Crashed:
-<span class="cp-wrong">0   CrashLibiOS                     0x1a0fe8            [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)</span>
-<span class="cp-wrong">1   CrashLibiOS                     0x1a0fe8            @objc CRLCrashSwift.crash() -> ()</span>
-2   CrashProbeiOS                   0x8ce19             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
-3   UIKit                           0x4e5a1755          -[UIApplication sendAction:to:from:forEvent:]
-4   UIKit                           0x4e5a16e1          -[UIControl sendAction:to:forEvent:]
-5   UIKit                           0x4e5896d3          -[UIControl _sendActionsForEvents:withEvent:]
-6   UIKit                           0x4e5a1005          -[UIControl touchesEnded:withEvent:]
-7   UIKit                           0x4e55af25          __UIGestureRecognizerUpdate
-8   UIKit                           0x4e599ec9          -[UIWindow _sendGesturesForEvent:]
-9   UIKit                           0x4e59967b          -[UIWindow sendEvent:]
-10  UIKit                           0x4e56a125          -[UIApplication sendEvent:]
-11  UIKit                           0x4e5686d3          __UIApplicationHandleEventQueue
-12  CoreFoundation                  0x4594fdff          ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
-13  CoreFoundation                  0x4594f9ed          ___CFRunLoopDoSources0
-14  CoreFoundation                  0x4594dd5b          ___CFRunLoopRun
-15  CoreFoundation                  0x4589d229          _CFRunLoopRunSpecific
-16  CoreFoundation                  0x4589d015          _CFRunLoopRunInMode
-17  GraphicsServices                0x4847dac9          _GSEventRunModal
-18  UIKit                           0x4e5d2189          _UIApplicationMain
-19  CrashProbeiOS                   0x8c14f             main (main.m:16)
+0   CrashLibiOS                     0x20500c            [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+1   CrashLibiOS                     0x20500c            @objc CRLCrashSwift.crash() -> ()
+2   CrashProbeiOS                   0xf0e03             -[CRLDetailViewController doCrash] (CRLDetailViewController.m:53)
+3   UIKit                           0x4e265755          -[UIApplication sendAction:to:from:forEvent:]
+4   UIKit                           0x4e2656e1          -[UIControl sendAction:to:forEvent:]
+5   UIKit                           0x4e24d6d3          -[UIControl _sendActionsForEvents:withEvent:]
+6   UIKit                           0x4e265005          -[UIControl touchesEnded:withEvent:]
+7   UIKit                           0x4e21ef25          _UIGestureRecognizerUpdate
+8   UIKit                           0x4e25dec9          -[UIWindow _sendGesturesForEvent:]
+9   UIKit                           0x4e25d67b          -[UIWindow sendEvent:]
+10  UIKit                           0x4e22e125          -[UIApplication sendEvent:]
+11  UIKit                           0x4e22c6d3          _UIApplicationHandleEventQueue
+12  CoreFoundation                  0x45613dff          __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
+13  CoreFoundation                  0x456139ed          __CFRunLoopDoSources0
+14  CoreFoundation                  0x45611d5b          __CFRunLoopRun
+15  CoreFoundation                  0x45561229          CFRunLoopRunSpecific
+16  CoreFoundation                  0x45561015          CFRunLoopRunInMode
+17  GraphicsServices                0x48141ac9          GSEventRunModal
+18  UIKit                           0x4e296189          UIApplicationMain
+19  CrashProbeiOS                   0xf00ff             main (main.m:16)


### PR DESCRIPTION
Provider name: Sentry
Repository URL: https://github.com/getsentry/CrashProbe
URL to the data: https://sentry.io/sentry-jj/crashprobe/
Username and password for the account: daniel+crashprobe@sentry.io:9p7U{sB64h7n2{]igCq&*/gw

Date of testing: 06/07/2017
SDK-Version: 3.0.7
Logo: https://sentry.io/branding/
Xcode Version 8.3.2 (8E2002)

Test environment per architecture:
arm7: iPad mini (P107AP), iOS 9.3.5
arm64: iPhone 7 Plus (D111AP), iOS 10.3.2