### PR TITLE
Updated results for Sentry v3.0.7 and XCode 8.3.2 (Mac)

### DIFF
--- a/mac/01/_sentry_x86_64.crash
+++ b/mac/01/_sentry_x86_64.crash
@@ -1,0 +1,35 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGSEGV)
+Exception Codes: SEGV_NOOP at 0x0000000000000001
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x1.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_platform.dylib        0xffff28bb4f5a      _platform_memmove$VARIANT$Haswell
+1   libsystem_pthread.dylib         0xffff28bc5af0      pthread_getname_np
+2   CrashLib                        0x10c34b31e         -[CRLCrashAsyncSafeThread crash] (CRLCrashAsyncSafeThread.m:41)
+3   CrashProbe                      0x20c227bba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+4   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+5   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+6   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+7   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+8   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+9   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+10  AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+11  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+12  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+13  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+14  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+15  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+16  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+17  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+18  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+19  AppKit                          0xfffef8de8427      -[NSApplication run]
+20  AppKit                          0xfffef8db2e0e      NSApplicationMain
+21  CrashProbe                      0x20c227e79         main (main.m:13)
+22  libdyld.dylib                   0xffff28790235      start

--- a/mac/01/data.json
+++ b/mac/01/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/02/_sentry_x86_64.crash
+++ b/mac/02/_sentry_x86_64.crash
@@ -1,0 +1,16 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+kaboom_exception*
+
+Thread 1 name: OGL Profiler
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+0   libsystem_kernel.dylib          0xffff289d134a      mach_msg_trap
+1   OpenGL                          0xffff077bc971      glcDebugListener
+2   libsystem_pthread.dylib         0xffff28bc493b      _pthread_body
+3   libsystem_pthread.dylib         0xffff28bc4887      _pthread_start
+4   libsystem_pthread.dylib         0xffff28bc408d      thread_start

--- a/mac/02/data.json
+++ b/mac/02/data.json
@@ -18,6 +18,9 @@
     },
     "Bugsnag": {
       "x86_64": "wrong"
+    },
+    "Sentry": {
+      "x86_64": "wrong"
     }
   }
 }

--- a/mac/03/_sentry_x86_64.crash
+++ b/mac/03/_sentry_x86_64.crash
@@ -1,0 +1,1 @@
+<span class="cp-wrong">No report</span>

--- a/mac/03/data.json
+++ b/mac/03/data.json
@@ -18,6 +18,9 @@
     },
     "Bugsnag": {
       "x86_64": "wrong"
+    },
+    "Sentry": {
+      "x86_64": "wrong"
     }
   }
 }

--- a/mac/04/_sentry_x86_64.crash
+++ b/mac/04/_sentry_x86_64.crash
@@ -1,0 +1,39 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x0000000000000010
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x10.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0xffff275a8057      objc_msgSend
+1   libsystem_trace.dylib           0xffff28c00a86      _os_log_impl_flatten_and_send
+2   libsystem_trace.dylib           0xffff28c0270d      _os_log_with_args_impl
+3   CoreFoundation                  0xfffefd819e57      _CFLogvEx3
+4   Foundation                      0xffff00cc9665      _NSLogv
+5   Foundation                      0xffff00cb47ee      NSLog
+6   CrashLib                        0x1034fada2         -[CRLCrashNSLog crash] (CRLCrashNSLog.m:41)
+7   CrashProbe                      0x2033cbbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+8   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+9   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+10  AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+11  AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+12  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+13  AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+14  AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+15  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+16  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+17  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+18  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+19  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+20  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+21  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+22  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+23  AppKit                          0xfffef8de8427      -[NSApplication run]
+24  AppKit                          0xfffef8db2e0e      NSApplicationMain
+25  CrashProbe                      0x2033cbe79         main (main.m:13)
+26  libdyld.dylib                   0xffff28790235      start

--- a/mac/04/data.json
+++ b/mac/04/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/05/_sentry_x86_64.crash
+++ b/mac/05/_sentry_x86_64.crash
@@ -1,0 +1,34 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x0000000000000040
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x40.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0xffff275a805d      objc_msgSend
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+1   CrashProbe                      0x2034ebbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x2034ebe79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/05/data.json
+++ b/mac/05/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "wrong"
+    },
+    "Sentry": {
+      "x86_64": "wrong"
     }
   }
 }

--- a/mac/06/_sentry_x86_64.crash
+++ b/mac/06/_sentry_x86_64.crash
@@ -1,0 +1,35 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x00004b3dd732bec0
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x4b3dd732bec0.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0xffff275a805d      objc_msgSend
+<span class="cp-wrong">Missing frame that shows where the crash occured</span>
+1   CrashLib                        0x107a8d826         -[CRLCrashReleasedObject crash] (CRLCrashReleasedObject.m:49)
+2   CrashProbe                      0x207965bba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+3   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+4   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+5   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+6   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+7   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+8   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+9   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+10  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+11  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+13  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+14  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+16  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+17  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+18  AppKit                          0xfffef8de8427      -[NSApplication run]
+19  AppKit                          0xfffef8db2e0e      NSApplicationMain
+20  CrashProbe                      0x207965e79         main (main.m:13)
+21  libdyld.dylib                   0xffff28790235      start

--- a/mac/06/data.json
+++ b/mac/06/data.json
@@ -18,6 +18,9 @@
     },
     "Bugsnag": {
       "x86_64": "incomplete"
+    },
+    "Sentry": {
+      "x86_64": "incomplete"
     }
   }
 }

--- a/mac/07/_sentry_x86_64.crash
+++ b/mac/07/_sentry_x86_64.crash
@@ -1,0 +1,33 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x000000010d6c6236
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x10d6c6236.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x10d6c629d         -[CRLCrashROPage crash] (CRLCrashROPage.m:42)
+1   CrashProbe                      0x20d59fbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x20d59fe79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/07/data.json
+++ b/mac/07/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Bugsnag": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/08/_sentry_x86_64.crash
+++ b/mac/08/_sentry_x86_64.crash
@@ -1,0 +1,33 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x00007fff861936ff
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x7fff861936ff.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x10e93d4a6         -[CRLCrashPrivInst crash] (CRLCrashPrivInst.m:40)
+1   CrashProbe                      0x20e816bba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x20e816e79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/08/data.json
+++ b/mac/08/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/09/_sentry_x86_64.crash
+++ b/mac/09/_sentry_x86_64.crash
@@ -1,0 +1,33 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0x0000000101f6d441
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 0, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x101f6d441         -[CRLCrashUndefInst crash] (CRLCrashUndefInst.m:40)
+1   CrashProbe                      0x201e48bba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x201e48e79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/09/data.json
+++ b/mac/09/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/10/_sentry_x86_64.crash
+++ b/mac/10/_sentry_x86_64.crash
@@ -1,0 +1,33 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference null pointer.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x10b48d188         -[CRLCrashNULL crash] (CRLCrashNULL.m:37)
+1   CrashProbe                      0x20b35cbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x20b35ce79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/10/data.json
+++ b/mac/10/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/11/_sentry_x86_64.crash
+++ b/mac/11/_sentry_x86_64.crash
@@ -1,0 +1,33 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x0000000119a0d000
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x119a0d000.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x10f0b322e         -[CRLCrashGarbage crash] (CRLCrashGarbage.m:46)
+1   CrashProbe                      0x20ef8bbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x20ef8be79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/11/data.json
+++ b/mac/11/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/12/_sentry_x86_64.crash
+++ b/mac/12/_sentry_x86_64.crash
@@ -1,0 +1,35 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x0000000116243000
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x116243000.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   <unknown>                       0x116243000         <redacted>
+<span class="cp-wrong">Missing frame where the crash occurs</span>
+1   CrashLib                        0x10f5e9394         -[CRLCrashNXPage crash] (CRLCrashNXPage.m:49)
+2   CrashProbe                      0x20f4bfbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+3   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+4   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+5   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+6   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+7   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+8   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+9   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+10  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+11  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+13  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+14  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+16  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+17  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+18  AppKit                          0xfffef8de8427      -[NSApplication run]
+19  AppKit                          0xfffef8db2e0e      NSApplicationMain
+20  CrashProbe                      0x20f4bfe79         main (main.m:13)
+21  libdyld.dylib                   0xffff28790235      start

--- a/mac/12/data.json
+++ b/mac/12/data.json
@@ -21,6 +21,9 @@
     },
     "Bugsnag": {
       "x86_64": "incomplete"
+    },
+    "Sentry": {
+      "x86_64": "wrong"
     }
   }
 }

--- a/mac/13/_sentry_x86_64.crash
+++ b/mac/13/_sentry_x86_64.crash
@@ -1,0 +1,17 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x00007fff55905ff8
+Crashed Thread: 0
+
+Application Specific Information:
+Stack overflow in (null)
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x109c22b47         -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+1   CrashLib                        0x109c22b4d         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)
+2   CrashLib                        0x109c22b4d         [inlined] -[CRLCrashStackGuard crash] (
+...
+99  CrashLib                        0x109c22b4d         [inlined] -[CRLCrashStackGuard crash] (CRLCrashStackGuard.m:39)

--- a/mac/13/data.json
+++ b/mac/13/data.json
@@ -18,6 +18,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/14/_sentry_x86_64.crash
+++ b/mac/14/_sentry_x86_64.crash
@@ -1,0 +1,33 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0x0000000106a2f570
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 0, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x106a2f570         -[CRLCrashTrap crash] (CRLCrashTrap.m:37)
+1   CrashProbe                      0x2068ffbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+2   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+3   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+4   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+5   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+6   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+7   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+8   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+9   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+10  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+11  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+13  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+14  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+16  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+17  AppKit                          0xfffef8de8427      -[NSApplication run]
+18  AppKit                          0xfffef8db2e0e      NSApplicationMain
+19  CrashProbe                      0x2068ffe79         main (main.m:13)
+20  libdyld.dylib                   0xffff28790235      start

--- a/mac/14/data.json
+++ b/mac/14/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/15/_sentry_x86_64.crash
+++ b/mac/15/_sentry_x86_64.crash
@@ -1,0 +1,34 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_CRASH (SIGABRT)
+Crashed Thread: 0
+
+Application Specific Information:
+Signal 6, Code 0
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_kernel.dylib          0xffff289d8d42      __pthread_kill
+1   libsystem_c.dylib               0xffff2885e420      abort
+2   CrashLib                        0x10204250f         -[CRLCrashAbort crash] (CRLCrashAbort.m:37)
+3   CrashProbe                      0x201f1dbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+4   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+5   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+6   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+7   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+8   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+9   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+10  AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+11  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+12  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+13  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+14  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+15  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+16  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+17  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+18  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+19  AppKit                          0xfffef8de8427      -[NSApplication run]
+20  AppKit                          0xfffef8db2e0e      NSApplicationMain
+21  CrashProbe                      0x201f1de79         main (main.m:13)
+22  libdyld.dylib                   0xffff28790235      start

--- a/mac/15/data.json
+++ b/mac/15/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/16/_sentry_x86_64.crash
+++ b/mac/16/_sentry_x86_64.crash
@@ -1,0 +1,44 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x000060800003b000
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x60800003b000.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_notify.dylib          0xffff28ba422d      _nc_table_find_64
+1   libsystem_notify.dylib          0xffff28ba121e      registration_node_find
+2   libsystem_notify.dylib          0xffff28ba278d      notify_check
+3   libsystem_c.dylib               0xffff28855164      notify_check_tz
+4   libsystem_c.dylib               0xffff28854d97      tzsetwall_basic
+5   libsystem_c.dylib               0xffff28856844      localtime_r
+6   CoreFoundation                  0xfffefd8ab42d      _populateBanner
+7   CoreFoundation                  0xfffefd8a9e24      _CFLogvEx2Predicate
+8   CoreFoundation                  0xfffefd819f4d      _CFLogvEx3
+9   Foundation                      0xffff00cc9665      _NSLogv
+10  Foundation                      0xffff00cb47ee      NSLog
+11  CrashLib                        0x10d870ac1         -[CRLCrashCorruptMalloc crash] (CRLCrashCorruptMalloc.m:46)
+12  CrashProbe                      0x20d74bbba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+13  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+14  AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+15  AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+16  AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+17  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+18  AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+19  AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+20  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+21  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+22  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+23  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+24  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+25  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+26  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+27  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+28  AppKit                          0xfffef8de8427      -[NSApplication run]
+29  AppKit                          0xfffef8db2e0e      NSApplicationMain
+30  CrashProbe                      0x20d74be79         main (main.m:13)
+31  libdyld.dylib                   0xffff28790235      start

--- a/mac/16/data.json
+++ b/mac/16/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/17/_sentry_x86_64.crash
+++ b/mac/17/_sentry_x86_64.crash
@@ -1,0 +1,35 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x00007fff8629318f
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x7fff8629318f.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libobjc.A.dylib                 0xffff275a7fc2      cache_getImp
+1   libobjc.A.dylib                 0xffff275a8ad4      _objc_msgSend_uncached
+2   CrashLib                        0x10e203d18         -[CRLCrashCorruptObjC crash] (CRLCrashCorruptObjC.m:70)
+3   CrashProbe                      0x20e0d8bba         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+4   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+5   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+6   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+7   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+8   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+9   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+10  AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+11  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+12  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+13  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+14  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+15  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+16  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+17  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+18  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+19  AppKit                          0xfffef8de8427      -[NSApplication run]
+20  AppKit                          0xfffef8db2e0e      NSApplicationMain
+21  CrashProbe                      0x20e0d8e79         main (main.m:13)
+22  libdyld.dylib                   0xffff28790235      start

--- a/mac/17/data.json
+++ b/mac/17/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "complete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }

--- a/mac/20/_sentry_x86_64.crash
+++ b/mac/20/_sentry_x86_64.crash
@@ -1,0 +1,15 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x00007fff861936ff
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0x7fff861936ff.
+
+Thread 0 name:
+Thread 0 Crashed:
+<span class="cp-wrong">0   CrashLib                        0x107dfec75         -[CRLCrashSmashStackBottom crash] (CRLCrashSmashStackBottom.m:55) | Wrong line number</span>
+<span class="cp-wrong">Missing frames</span>
+

--- a/mac/20/data.json
+++ b/mac/20/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "wrong"
+    },
+    "Sentry": {
+      "x86_64": "incomplete"
     }
   }
 }

--- a/mac/21/_sentry_x86_64.crash
+++ b/mac/21/_sentry_x86_64.crash
@@ -1,0 +1,14 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_ACCESS (SIGBUS)
+Exception Codes: BUS_NOOP at 0x000000c42047b000
+Crashed Thread: 0
+
+Application Specific Information:
+Attempted to dereference garbage pointer 0xc42047b000.
+
+Thread 0 name:
+Thread 0 Crashed:
+0   libsystem_platform.dylib        0xffff28bb5c12      _platform_bzero$VARIANT$Haswell
+<span class="cp-wrong">Missing frames that show where the crash occured</span>

--- a/mac/21/data.json
+++ b/mac/21/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "wrong"
+    },
+    "Sentry": {
+      "x86_64": "wrong"
     }
   }
 }

--- a/mac/22/_sentry_x86_64.crash
+++ b/mac/22/_sentry_x86_64.crash
@@ -1,0 +1,34 @@
+OS Version: macOS 10.12.5 (16F73)
+Report Version: 104
+
+Exception Type: EXC_BAD_INSTRUCTION (SIGILL)
+Exception Codes: ILL_NOOP at 0x000000010edc5dc4
+Crashed Thread: 0
+
+Application Specific Information:
+Exception 2, Code 0, Subcode 8
+
+Thread 0 name:
+Thread 0 Crashed:
+0   CrashLib                        0x10edc5dc4         [inlined] CRLCrashSwift.crash() -> () (CRLCrashSwift.swift:36)
+1   CrashLib                        0x10edc5dc4         @objc CRLCrashSwift.crash() -> ()
+2   CrashProbe                      0x20eca7bc3         -[CRLMainWindowController causeCrash:] (CRLMainWindowController.m:72)
+3   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+4   AppKit                          0xfffef9571721      -[NSApplication(NSResponder) sendAction:to:from:]
+5   AppKit                          0xfffef9055cc4      -[NSControl sendAction:to:]
+6   AppKit                          0xfffef9055bec      __26-[NSCell _sendActionFrom:]_block_invoke
+7   libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+8   AppKit                          0xfffef9055b44      -[NSCell _sendActionFrom:]
+9   AppKit                          0xfffef9098539      -[NSButtonCell _sendActionFrom:]
+10  libsystem_trace.dylib           0xffff28bf63a7      _os_activity_initiate_impl
+11  AppKit                          0xfffef9054426      -[NSCell trackMouse:inRect:ofView:untilMouseUp:]
+12  AppKit                          0xfffef9098272      -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:]
+13  AppKit                          0xfffef9052ddb      -[NSControl mouseDown:]
+14  AppKit                          0xfffef96ed24f      -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:]
+15  AppKit                          0xfffef96e9a6c      -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:]
+16  AppKit                          0xfffef96e8f0a      -[NSWindow(NSEventRouting) sendEvent:]
+17  AppKit                          0xfffef956d681      -[NSApplication(NSEvent) sendEvent:]
+18  AppKit                          0xfffef8de8427      -[NSApplication run]
+19  AppKit                          0xfffef8db2e0e      NSApplicationMain
+20  CrashProbe                      0x20eca7e82         main (main.m:13)
+21  libdyld.dylib                   0xffff28790235      start

--- a/mac/22/data.json
+++ b/mac/22/data.json
@@ -17,6 +17,9 @@
     },
     "Bugsnag": {
       "x86_64": "incomplete"
+    },
+    "Sentry": {
+      "x86_64": "complete"
     }
   }
 }


### PR DESCRIPTION
These are the test results for Sentry on MacOS with the same build as iOS.

Provider name: Sentry
Repository URL: https://github.com/getsentry/CrashProbe
URL to the data: https://sentry.io/sentry-jj/crashprobe/
Username and password for the account: daniel+crashprobe@sentry.io:9p7U{sB64h7n2{]igCq&*/gw

Date of testing: 07/03/2017
SDK-Version: 3.0.7
Logo: https://sentry.io/branding/
Xcode Version 8.3.2 (8E2002)

Test environment per architecture:
x86_64: MacBook Pro (Retina, 13-inch, no Touchbar, 2016), OS X 10.12.5